### PR TITLE
Restructuring workflow - Ensure that images are published only on main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,17 @@ workflows:
   version: 2
   test_and_package:
     jobs:
-      - test_and_publish
+      - test
+      - publish:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master
 
 version: 2
 jobs:
-  test_and_publish:
+  test:
     docker:
       - image: cimg/go:1.13.15
 
@@ -38,7 +44,12 @@ jobs:
       
       - store_test_results:
           path: /tmp/test-results
+  
+  publish:
+    docker:
+      - image: cimg/go:1.13.15
 
+    steps:
       - run: 
           name: build and publish docker img
           command: |
@@ -46,4 +57,3 @@ jobs:
             docker build -t docker.pkg.github.com/clamp-orchestrator/clamp-core/clamp-core:$CIRCLE_SHA1 .
             docker push docker.pkg.github.com/clamp-orchestrator/clamp-core/clamp-core:$CIRCLE_SHA1
             docker system prune -f -a
-


### PR DESCRIPTION
To ensure that docker images are published to what gets merged on the main branch and not on the other branches. This will ensure that published artifacts are always representing the state of master. Adding more stuff for issue https://github.com/clamp-orchestrator/clamp-core/issues/31