### PR TITLE
Refactoring workflow creation code to remove nested step update

### DIFF
--- a/models/workflow.go
+++ b/models/workflow.go
@@ -7,7 +7,37 @@ import (
 	"time"
 )
 
-//Workflow is a structure to store the service request details
+type stepEnricher func(Step, int) Step
+type stepType string
+
+var stepEnrichmentMap map[stepType]stepEnricher = map[stepType]stepEnricher{
+
+	"AMQP": func(step Step, stepId int) Step {
+		step.ID = stepId
+		step.Val.(*executors.AMQPVal).ReplyTo = config.ENV.QueueName
+		step.Type = utils.AsyncStepType
+		return step
+	},
+
+	"HTTP": func(step Step, stepId int) Step {
+		step.ID = stepId
+		if step.Type == "" {
+			step.Type = utils.SyncStepType
+		}
+		return step
+	},
+
+	"KAFKA": func(step Step, stepId int) Step {
+		step.ID = stepId
+		step.Val.(*executors.KafkaVal).ReplyTo = config.ENV.KafkaConsumerTopicName
+		step.Type = utils.AsyncStepType
+		return step
+	},
+}
+
+//Workflow is a structure to store the workflow details. A workflow record represents a definition of a workflow with multiple steps in it.
+//A workflow when trigerred creates a service request. Each step in a workflow is triggered sequentially and status for workflow is tracked
+//to completion (success/failure)
 type Workflow struct {
 	ID          string    `json:"id"`
 	Name        string    `json:"name" binding:"required"`
@@ -18,55 +48,8 @@ type Workflow struct {
 	Steps       []Step    `json:"steps" binding:"required,gt=0,dive"`
 }
 
-//Create a new work flow for a given service flow and return service flow details
-func CreateWorkflow(workflowRequest Workflow) Workflow {
-	stepCounter :=0
-	for i := 0; i < len(workflowRequest.Steps); i++ {
-		stepCounter++
-		workflowRequest.Steps[i].ID = stepCounter
-		switch workflowRequest.Steps[i].Mode {
-			case "AMQP":
-				{
-					workflowRequest.Steps[i].Val.(*executors.AMQPVal).ReplyTo = config.ENV.QueueName
-					workflowRequest.Steps[i].Type = utils.AsyncStepType
-				}
-			case "HTTP":
-				{
-					if workflowRequest.Steps[i].Type == "" {
-						workflowRequest.Steps[i].Type = utils.SyncStepType
-					}
-				}
-			case "KAFKA":
-				{
-					workflowRequest.Steps[i].Val.(*executors.KafkaVal).ReplyTo = config.ENV.KafkaConsumerTopicName
-					workflowRequest.Steps[i].Type = utils.AsyncStepType
-				}
-		}
-		UpdateStepCounterForEachOfSubSteps(workflowRequest, i, stepCounter)
-	}
-	return newServiceFlow(workflowRequest)
-}
-
-func UpdateStepCounterForEachOfSubSteps(workflowRequest Workflow, i int, stepCounter int) {
-	if workflowRequest.Steps[i].OnFailure != nil {
-		stepCounter = UpdateSubStepsIds(workflowRequest, i, stepCounter)
-	}
-}
-
-func UpdateSubStepsIds(workflowRequest Workflow, i int, stepCounter int) int {
-	var subSteps []Step
-	subSteps = workflowRequest.Steps[i].OnFailure
-	for subStepID := range subSteps {
-		stepCounter++
-		subSteps[subStepID].ID = stepCounter
-	}
-	return stepCounter
-}
-
-func newServiceFlow(workflow Workflow) Workflow {
-	return Workflow{ID: workflow.ID, Name: workflow.Name, Description: workflow.Description, Enabled: true, CreatedAt: time.Time{}, UpdatedAt: time.Time{}, Steps: workflow.Steps}
-}
-
+//PGWorkflow is a struct which represents the structure of workflow record in the postgres data store. The Workflow struct
+//is converted to PGWorkflow while saving and vice versa during retrieval.
 type PGWorkflow struct {
 	tableName   struct{} `pg:"workflows"`
 	ID          string
@@ -78,6 +61,7 @@ type PGWorkflow struct {
 	Steps       []Step
 }
 
+//ToPGWorkflow converts a Workflow object into a Postgres specific workflow stucture that is used for persisting to postgres specifically
 func (workflow Workflow) ToPGWorkflow() PGWorkflow {
 	return PGWorkflow{
 		ID:          workflow.ID,
@@ -90,6 +74,7 @@ func (workflow Workflow) ToPGWorkflow() PGWorkflow {
 	}
 }
 
+//ToWorkflow converts a PGWorkflow struct to a Workflow structure that is used in the application to pass around a workflow defintion.
 func (pgWorkflow PGWorkflow) ToWorkflow() Workflow {
 	return Workflow{
 		ID:          pgWorkflow.ID,
@@ -99,5 +84,48 @@ func (pgWorkflow PGWorkflow) ToWorkflow() Workflow {
 		CreatedAt:   pgWorkflow.CreatedAt,
 		UpdatedAt:   pgWorkflow.UpdatedAt,
 		Steps:       pgWorkflow.Steps,
+	}
+}
+
+//CreateWorkflow creates a new work flow with the given Workflow defintion and step details. The workflow is persisted and can be triggered.
+//Once a workflow has been created it is not possible to change/edit it currently. During creation each step is assigned an id, which is unique to
+//the workflow, a type and a reply to queue name for Kafka and AMQP to ensure that for async channels a reply channel is set during workflow
+//creation.
+func CreateWorkflow(workflowRequest Workflow) Workflow {
+	stepCount := 0
+	for i := 0; i < len(workflowRequest.Steps); i++ {
+		stepCount++
+		stepTypeName := stepType(workflowRequest.Steps[i].Mode)
+		workflowRequest.Steps[i] = stepEnrichmentMap[stepTypeName](workflowRequest.Steps[i], stepCount)
+		updateStepCounterForEachOfSubSteps(workflowRequest, i, stepCount)
+	}
+	return newServiceFlow(workflowRequest)
+}
+
+func updateStepCounterForEachOfSubSteps(workflowRequest Workflow, i int, stepCount int) {
+	if workflowRequest.Steps[i].OnFailure != nil {
+		stepCount = updateSubStepsIds(workflowRequest, i, stepCount)
+	}
+}
+
+func updateSubStepsIds(workflowRequest Workflow, i int, stepCount int) int {
+	var subSteps []Step
+	subSteps = workflowRequest.Steps[i].OnFailure
+	for subStepID := range subSteps {
+		stepCount++
+		subSteps[subStepID].ID = stepCount
+	}
+	return stepCount
+}
+
+func newServiceFlow(workflow Workflow) Workflow {
+	return Workflow{
+		ID:          workflow.ID,
+		Name:        workflow.Name,
+		Description: workflow.Description,
+		Enabled:     true,
+		CreatedAt:   time.Time{},
+		UpdatedAt:   time.Time{},
+		Steps:       workflow.Steps,
 	}
 }


### PR DESCRIPTION
I have attempted to improve the following things in this commit. Please take a look and share your opinion. 

* Ensure that all public structures are in the top part of the file and all private functions and structs are in the bottom part of the file. 
* Add documentation that is reasonable for now, to all the public contracts
* Simplify the public contract as much as possible. So in this case, we have a `Workflow`, `PGWorkflow` as types, and `CreateWorkflow` as the method to create a workflow and `ToWorkflow` and `ToPGWorkflow` as the utility conversion methods. To the outside world, this makes the contract small and understandable. 
* Instead of doing an if/else or switch case, the class has an enricherMap which holds a step type and an anonymous function for it that will be applied. 
* Also note that key is not a plain string, but an alias type for a string called `stepType`. This adds to readability. Since we want to scope visibility, the type is private. 
* The value in the map is also an alias type for a function that takes a step, id for step and returns back an updated step. This allows multiple-step types to be added. However, overall we can possibly find a better mechanism to enrich steps and sub-steps. 

I think from the code it is evident that sub-steps were added later on as we handle the id assignment for them separately instead of something like recursion. But I'll think and improve this a bit more. 

I have not reviewed the tests and will do that next to improve the coverage and style. Please take a look and let's have a discussion. Having the discussion will promote consistency in code as we all will agree on things. 