### PR TITLE
Run integration test in ci server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,12 +69,13 @@ jobs:
             if [ $CIRCLE_BRANCH == 'master' ]; then
               ./cc-test-reporter before-build
             fi
-            gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- clamp-core/executors clamp-core/models clamp-core/services clamp-core/executors -coverprofile=c.out
+            go build main.go
+            ./main migrate --migrate-only=yes
+            gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- clamp-core/executors clamp-core/models clamp-core/services clamp-core/executors clamp-core/handlers -coverprofile=c.out
             if [ $CIRCLE_BRANCH == 'master' ]; then
               ./cc-test-reporter after-build --coverage-input-type gocov -p clamp-core --exit-code $?
             fi
-            
-      
+          
       - store_test_results:
           path: /tmp/test-results
 
@@ -83,8 +84,9 @@ jobs:
       - image: cimg/go:1.13.15
 
     steps:
-      - setup_remote_docker
       - checkout
+      - setup_remote_docker
+
       - run: 
           name: build and publish docker img
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
             fi
             go build main.go
             ./main migrate --migrate-only=yes
-            gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- clamp-core/executors clamp-core/models clamp-core/services clamp-core/executors clamp-core/handlers -coverprofile=c.out
+            gotestsum --junitfile ${TEST_RESULTS}/gotestsum-report.xml -- clamp-core/executors clamp-core/models clamp-core/services clamp-core/handlers -coverprofile=c.out
             if [ $CIRCLE_BRANCH == 'master' ]; then
               ./cc-test-reporter after-build --coverage-input-type gocov -p clamp-core --exit-code $?
             fi

--- a/main.go
+++ b/main.go
@@ -5,14 +5,20 @@ import (
 	"clamp-core/handlers"
 	"clamp-core/listeners"
 	"clamp-core/migrations"
+	"clamp-core/models"
 	"log"
 	"os"
 )
 
 func main() {
-	//defer repository.CloseDB()
+	var cliArgs models.CLIArguments = os.Args[1:]
 	os.Setenv("PORT", config.ENV.PORT)
 	migrations.Migrate()
+
+	if cliArgs.Parse().Find("migrate-only", "no") == "yes" {
+		os.Exit(0)
+	}
+
 	listeners.AmqpStepResponseListener.Listen()
 	listeners.KafkaStepResponseListener.Listen()
 	handlers.LoadHTTPRoutes()

--- a/models/initialization.go
+++ b/models/initialization.go
@@ -1,0 +1,41 @@
+package models
+
+import "strings"
+
+//Arguments holds a key value pair that represent an argument with its respective value
+//There can be only one argument with that name. The name is case insensitive
+type Arguments map[string]string
+
+//CLIArguments is a list if arguments provided as an array of strings. It can process those arguments
+//and convert into an models.Arguments type which hold them as key value pairs
+type CLIArguments []string
+
+//Parse parses all the arguments within models.CliArguments type and return them as models.Argument type
+func (cliArgs CLIArguments) Parse() Arguments {
+	args := Arguments{}
+
+	for _, val := range cliArgs {
+		splits := strings.Split(val, "=")
+		if len(splits) > 1 {
+			args[cleanUp(splits[0])] = splits[1]
+		}
+	}
+
+	return args
+}
+
+//Find the argument value using name of the argument as lookupName. defaultValue is the value that is returned when the
+//argument with lookupName is not found in the models.Argument type
+func (args Arguments) Find(lookupName string, defaultValue string) string {
+	if val, ok := args[lookupName]; ok {
+		return val
+	}
+
+	return defaultValue
+}
+
+func cleanUp(value string) string {
+	cleanedUpValue := strings.Replace(value, "--", "", -1)
+	cleanedUpValue = strings.ToLower(cleanedUpValue)
+	return cleanedUpValue
+}

--- a/models/initialization_test.go
+++ b/models/initialization_test.go
@@ -1,0 +1,48 @@
+package models
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldInitializeArgumentsWithOnlyMigrationArgument(t *testing.T) {
+	expectedLen := 1
+	expectedValue := "true"
+
+	var cliArguments CLIArguments = []string{"migrate", "--migration-only=true"}
+
+	arguments := cliArguments.Parse()
+	migrateOnlyValue := arguments.Find("migration-only", "false")
+
+	assert.Equal(t, expectedLen, len(arguments), fmt.Sprintf("Expected %d argument to be available but there were %d", expectedLen, len(arguments)))
+	assert.Equal(t, expectedValue, migrateOnlyValue, fmt.Sprintf("Expected %s to be the value for migration-only argument but was %s", expectedValue, migrateOnlyValue))
+}
+
+func TestShouldEnsureThatArgumentNameIsCaseSensitiveAndValueIsCaseSensitive(t *testing.T) {
+	expectedValue := "InSaNe"
+
+	var cliArguments CLIArguments = []string{"logDebug", "--joggingLevel=InSaNe"}
+	karmaArgsValue := cliArguments.Parse().Find("jogginglevel", "rookie")
+
+	assert.Equal(t, expectedValue, karmaArgsValue, fmt.Sprintf("Expected %s to be the value for joggingLevel argument but was %s", expectedValue, karmaArgsValue))
+}
+
+func TestShouldReturnDefaultValueWhenArgumentNotPresent(t *testing.T) {
+	expectedValue := "no"
+
+	var cliArguments CLIArguments = []string{"logDebug", "--karma=3"}
+	karmaArgsValue := cliArguments.Parse().Find("mana", "no")
+
+	assert.Equal(t, expectedValue, karmaArgsValue, fmt.Sprintf("Expected %s to be the value for mana argument but was %s", expectedValue, karmaArgsValue))
+}
+
+func TestShouldEnsureThatArgumentsCanBeAnEmptyList(t *testing.T) {
+	expectedLen := 0
+
+	var cliArguments CLIArguments = []string{}
+	arguments := cliArguments.Parse()
+
+	assert.Equal(t, expectedLen, len(arguments), fmt.Sprintf("Expected %d to be the size for arguments argument but was %d", expectedLen, len(arguments)))
+}


### PR DESCRIPTION
I have added support for running migrations without having to start the server via start time arguments. During integration test run, the migrations are run before integration tests are triggered. 

Closes issue #53 
