### PR TITLE
#68 | Kafka or Rabbitmq to be optional to use Clamp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,8 @@ jobs:
             CLAMP_DB_CONNECTION_STR: "host=localhost:5432 user=clamptest dbname=clamptest"
             CLAMP_KAFKA_CONNECTION_STR: "localhost:9092"
             CLAMP_QUEUE_CONNECTION_STR: "amqp://guest:guest@localhost:5672/"
+            ENABLE_KAFKA_INTEGRATION: true
+            EnableRabbitMQIntegration: true
           command: |
             if [ $CIRCLE_BRANCH == 'master' ]; then
               ./cc-test-reporter before-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
             CLAMP_KAFKA_CONNECTION_STR: "localhost:9092"
             CLAMP_QUEUE_CONNECTION_STR: "amqp://guest:guest@localhost:5672/"
             ENABLE_KAFKA_INTEGRATION: true
-            EnableRabbitMQIntegration: true
+            ENABLE_AMQP_INTEGRATION: true
           command: |
             if [ $CIRCLE_BRANCH == 'master' ]; then
               ./cc-test-reporter before-build

--- a/config/env.go
+++ b/config/env.go
@@ -45,6 +45,9 @@ var ENV = struct {
 	*/
 	PORT          string   `env:"APP_PORT" envDefault:"8080"`
 	AllowOrigins  []string `env:"ALLOW_ORIGINS" envDefault:"http://localhost:3000,http://54.149.76.62"`
+
+	EnableKafkaIntegration    bool `env:"ENABLE_KAFKA_INTEGRATION" envDefault:false`
+	EnableRabbitMQIntegration bool `env:"ENABLE_AMQP_INTEGRATION" envDefault:false`
 }{}
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -19,8 +19,12 @@ func main() {
 		os.Exit(0)
 	}
 
-	listeners.AmqpStepResponseListener.Listen()
-	listeners.KafkaStepResponseListener.Listen()
+	if config.ENV.EnableKafkaIntegration {
+		listeners.AmqpStepResponseListener.Listen()
+	}
+	if config.ENV.EnableKafkaIntegration {
+		listeners.KafkaStepResponseListener.Listen()
+	}
 	handlers.LoadHTTPRoutes()
 	log.Println("Calling listener")
 }

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	if config.ENV.EnableKafkaIntegration {
+	if config.ENV.EnableRabbitMQIntegration {
 		listeners.AmqpStepResponseListener.Listen()
 	}
 	if config.ENV.EnableKafkaIntegration {


### PR DESCRIPTION
Kafka or Rabbitmq to be optional to use Clamp based on ENV, presently disabling it by default

To Start off clamp, we do not need Kafka or RabbitMQ, if required it can be enabled in config.go by making flag `**EnableKafkaIntegration**` and `**EnableRabbitMQIntegration**` to `**true**` based on the requirement
