### PR TITLE
Change workflows pageNumber to start from 1 instead of 0

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -272,6 +272,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14 h1:PyYN9JH5jY9j6av01SpfRMb+1DWg/i3MbGOKPxJ2wjM=
 github.com/swaggo/files v0.0.0-20190704085106-630677cd5c14/go.mod h1:gxQT6pBGRuIGunNf/+tSOB5OHvguWi8Tbt82WOkf35E=
@@ -455,6 +456,7 @@ gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v1.4.0 h1:BjtEgfuw8Qyd+jPvQz8CfoxiO/UjFEidWinwEXZiWv0=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=

--- a/handlers/workflow_handler.go
+++ b/handlers/workflow_handler.go
@@ -127,13 +127,13 @@ func getWorkflows() gin.HandlerFunc {
 		pageNumberStr := c.Query("pageNumber")
 		sortByQuery := c.Query("sortBy")
 		if pageSizeStr == "" || pageNumberStr == "" {
-			err := errors.New("page number or page size is not been defined")
+			err := errors.New("page number or page size has not been defined")
 			prepareErrorResponse(err, c)
 			return
 		}
 		pageNumber, pageNumberErr := strconv.Atoi(pageNumberStr)
 		pageSize, pageSizeErr := strconv.Atoi(pageSizeStr)
-		if pageNumberErr != nil || pageSizeErr != nil || pageSize < 0 || pageNumber < 0 {
+		if pageNumberErr != nil || pageSizeErr != nil || pageSize < 1 || pageNumber < 1 {
 			err := errors.New("page number or page size is not in proper format")
 			prepareErrorResponse(err, c)
 			return

--- a/handlers/workflow_handler_test.go
+++ b/handlers/workflow_handler_test.go
@@ -208,7 +208,7 @@ func TestShouldGetAllWorkflowsByPage(t *testing.T) {
 	router := setupRouter()
 	w := httptest.NewRecorder()
 
-	req, _ := http.NewRequest("GET", "/workflows?pageNumber=0&pageSize=1", nil)
+	req, _ := http.NewRequest("GET", "/workflows?pageNumber=1&pageSize=1", nil)
 	router.ServeHTTP(w, req)
 
 	bodyStr := w.Body.String()
@@ -224,7 +224,7 @@ func TestShouldThrowErrorIfQueryParamsAreNotPassedInGetAllWorkflows(t *testing.T
 	router := setupRouter()
 	w := httptest.NewRecorder()
 
-	req, _ := http.NewRequest("GET", "/workflows?pageNumber=0", nil)
+	req, _ := http.NewRequest("GET", "/workflows?pageNumber=1", nil)
 	router.ServeHTTP(w, req)
 
 	bodyStr := w.Body.String()
@@ -236,11 +236,43 @@ func TestShouldThrowErrorIfQueryParamsAreNotPassedInGetAllWorkflows(t *testing.T
 	assert.Equal(t, "page number or page size is not been defined", jsonResp.Message)
 }
 
+func TestShouldThrowErrorIfPageNumberIsLessThanOne(t *testing.T) {
+	router := setupRouter()
+	w := httptest.NewRecorder()
+
+	req, _ := http.NewRequest("GET", "/workflows?pageNumber=0&pageSize=1", nil)
+	router.ServeHTTP(w, req)
+
+	bodyStr := w.Body.String()
+	var jsonResp models.ClampErrorResponse
+	json.Unmarshal([]byte(bodyStr), &jsonResp)
+
+	assert.Equal(t, 400, w.Code)
+	assert.NotNil(t, jsonResp)
+	assert.Equal(t, "page number or page size is not in proper format", jsonResp.Message)
+}
+
+func TestShouldThrowErrorIfPageSizeIsLessThanOne(t *testing.T) {
+	router := setupRouter()
+	w := httptest.NewRecorder()
+
+	req, _ := http.NewRequest("GET", "/workflows?pageNumber=1&pageSize=0", nil)
+	router.ServeHTTP(w, req)
+
+	bodyStr := w.Body.String()
+	var jsonResp models.ClampErrorResponse
+	json.Unmarshal([]byte(bodyStr), &jsonResp)
+
+	assert.Equal(t, 400, w.Code)
+	assert.NotNil(t, jsonResp)
+	assert.Equal(t, "page number or page size is not in proper format", jsonResp.Message)
+}
+
 func TestShouldThrowErrorIfQueryParamsAreNotValidValuesInGetAllWorkflows(t *testing.T) {
 	router := setupRouter()
 	w := httptest.NewRecorder()
 
-	req, _ := http.NewRequest("GET", "/workflows?pageNumber=0&pageSize=-1", nil)
+	req, _ := http.NewRequest("GET", "/workflows?pageNumber=1&pageSize=-1", nil)
 	router.ServeHTTP(w, req)
 
 	bodyStr := w.Body.String()
@@ -257,7 +289,7 @@ func TestShouldThrowErrorIfSortByStringIsNotInTheRightFormat(t *testing.T) {
 	w := httptest.NewRecorder()
 	sortByString := `id,`
 	urlEncodedSortValue := url.QueryEscape(sortByString)
-	req, _ := http.NewRequest("GET", "/workflows?pageNumber=0&pageSize=1&sortBy="+urlEncodedSortValue, nil)
+	req, _ := http.NewRequest("GET", "/workflows?pageNumber=1&pageSize=1&sortBy="+urlEncodedSortValue, nil)
 	router.ServeHTTP(w, req)
 
 	bodyStr := w.Body.String()

--- a/handlers/workflow_handler_test.go
+++ b/handlers/workflow_handler_test.go
@@ -233,7 +233,7 @@ func TestShouldThrowErrorIfQueryParamsAreNotPassedInGetAllWorkflows(t *testing.T
 
 	assert.Equal(t, 400, w.Code)
 	assert.NotNil(t, jsonResp)
-	assert.Equal(t, "page number or page size is not been defined", jsonResp.Message)
+	assert.Equal(t, "page number or page size has not been defined", jsonResp.Message)
 }
 
 func TestShouldThrowErrorIfPageNumberIsLessThanOne(t *testing.T) {

--- a/repository/postgres.go
+++ b/repository/postgres.go
@@ -176,7 +176,7 @@ func (p *postgres) GetWorkflows(pageNumber int, pageSize int, sortFields models.
 			query = query.Order(reference + " " + order)
 		}
 	}
-	err := query.Offset(pageSize * pageNumber).
+	err := query.Offset(pageSize * (pageNumber - 1)).
 		Limit(pageSize).Select()
 	if err != nil {
 		return []models.Workflow{}, err

--- a/services/workflow_service_test.go
+++ b/services/workflow_service_test.go
@@ -67,21 +67,47 @@ func TestFindWorkflowByWorkflowName(t *testing.T) {
 func TestGetWorkflowsWithoutSortByArgs(t *testing.T) {
 	workflow := prepareWorkflow()
 	var sortBy models.SortByFields
+	var receivedSortByArgs models.SortByFields
+	var pgNumberReceived int
+	var pgSizeReceived int
 	getWorkflowsMock = func(pageNumber int, pageSize int, sortBy models.SortByFields) ([]models.Workflow, error) {
+		receivedSortByArgs = sortBy
+		pgNumberReceived = pageNumber
+		pgSizeReceived = pageSize
 		return []models.Workflow{workflow}, nil
+
 	}
-	resp, err := GetWorkflows(0, 1, sortBy)
+	pageSize := 1
+	pageNumber := 1
+	resp, err := GetWorkflows(pageNumber, pageSize, sortBy)
+
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(resp))
+	assert.Equal(t, pageSize, pgSizeReceived)
+	assert.Equal(t, pageNumber, pgNumberReceived)
+	assert.Equal(t, receivedSortByArgs, sortBy)
 }
 
 func TestGetWorkflowsWithSortByArgs(t *testing.T) {
 	workflow := prepareWorkflow()
 	sortBy := models.SortByFields{{Key: "id", Order: "asc"}}
+	var receivedSortByArgs models.SortByFields
+	var pgNumberReceived int
+	var pgSizeReceived int
 	getWorkflowsMock = func(pageNumber int, pageSize int, sortBy models.SortByFields) ([]models.Workflow, error) {
+		receivedSortByArgs = sortBy
+		pgNumberReceived = pageNumber
+		pgSizeReceived = pageSize
 		return []models.Workflow{workflow}, nil
+
 	}
-	resp, err := GetWorkflows(0, 1, sortBy)
+	pageSize := 1
+	pageNumber := 1
+	resp, err := GetWorkflows(pageNumber, pageSize, sortBy)
+
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(resp))
+	assert.Equal(t, pageSize, pgSizeReceived)
+	assert.Equal(t, pageNumber, pgNumberReceived)
+	assert.Equal(t, receivedSortByArgs, sortBy)
 }


### PR DESCRIPTION
Closes #66 

- Fixed pagination to start from 1 instead of zero 

> The conversion to 0 is handled by postgres connector

-Fixed a minor grammatical error in Error response being sent back
 
-Made workflow services tests more robust for pagination