### PR TITLE
Changes to optionally include Prometheus and Grafana in Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,17 @@ Clamp is a workflow management and microservices orchestrator. It has been writt
 ## Backlogs & Issues
 
 - [Project dashboard](https://github.com/orgs/clamp-orchestrator/projects/1)
+
+## Docker Compose
+
+Clamp Core and its dependencies can be run through Docker Compose with the following command
+
+```bash
+$ docker-compose up
+```
+
+Optionally, you can run the following command if you want to inspect Clamp Core metrics through Prometheus annd Grafana.
+
+```bash
+$ docker-compose -f docker-compose.yml -f prometheus-grafana.yml u
+```

--- a/prometheus-grafana.yml
+++ b/prometheus-grafana.yml
@@ -1,0 +1,20 @@
+version: "3.8"
+services:
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    depends_on:
+      - clamp
+    links:
+      - clamp
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    links:
+      - prometheus

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,14 @@
+# A scrape configuration scraping a Node Exporter and the Prometheus server
+# itself.
+scrape_configs:
+  # Scrape Prometheus itself every 5 seconds.
+  - job_name: 'prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'clamp'
+    metrics_path: '/metrics'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['clamp:8080']


### PR DESCRIPTION
The changeset includes Docker Compose specification for Prometheus and Grafana. The Docker Compose specification is in a separate YAML file to allow optional usage.

This PR addresses issue #85.