### PR TITLE
Priyank | Fixing error message comparision to avoid platform specific nuances

### DIFF
--- a/executors/http_executor_test.go
+++ b/executors/http_executor_test.go
@@ -74,7 +74,7 @@ func TestHttpVal_DoExecute(t *testing.T) {
 			},
 			want:       map[string]interface{}{"id": "1234", "name": "ABC", "email": "abc@sahaj.com", "org": "sahaj"},
 			wantErr:    true,
-			wantErrMsg: "Get http://localhost:3333/api/v1/user: dial tcp 127.0.0.1:3333: connect: connection refused",
+			wantErrMsg: "connect: connection refused",
 		},
 	}
 	for _, tt := range tests {
@@ -90,7 +90,7 @@ func TestHttpVal_DoExecute(t *testing.T) {
 				return
 			}
 			if err != nil {
-				assert.EqualError(t, err, tt.wantErrMsg)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
 			} else {
 				var responsePayload map[string]interface{}
 				json.Unmarshal([]byte(got.(string)), &responsePayload)


### PR DESCRIPTION
Currently, the tests were receiving different error messages on OSX vs Ubuntu. Doing a substring match in tests to ensure they have consistent representations.