### PR TITLE
Replace structs by-value usages with by-ref usages

### DIFF
--- a/executors/amqp_executor.go
+++ b/executors/amqp_executor.go
@@ -19,7 +19,7 @@ type AMQPVal struct {
 }
 
 // DoExecute : Connection to Rabbitmq and sending message into Exchange
-func (val AMQPVal) DoExecute(requestBody interface{}, prefix string) (interface{}, error) {
+func (val *AMQPVal) DoExecute(requestBody interface{}, prefix string) (interface{}, error) {
 	log.Debugf("%s AMQP Executor: Executing amqp %s body:%v", prefix, val.getName(), requestBody)
 
 	conn, err := amqp.Dial(val.ConnectionURL)
@@ -45,7 +45,7 @@ func (val AMQPVal) DoExecute(requestBody interface{}, prefix string) (interface{
 	}
 }
 
-func sendMessageToQueue(ch *amqp.Channel, val AMQPVal, body interface{}, prefix string) (interface{}, error) {
+func sendMessageToQueue(ch *amqp.Channel, val *AMQPVal, body interface{}, prefix string) (interface{}, error) {
 	bytes, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func sendMessageToQueue(ch *amqp.Channel, val AMQPVal, body interface{}, prefix 
 	return nil, nil
 }
 
-func sendMessageToExchange(ch *amqp.Channel, val AMQPVal, body interface{}, prefix string) (interface{}, error) {
+func sendMessageToExchange(ch *amqp.Channel, val *AMQPVal, body interface{}, prefix string) (interface{}, error) {
 	bytes, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func sendMessageToExchange(ch *amqp.Channel, val AMQPVal, body interface{}, pref
 	return nil, nil
 }
 
-func (val AMQPVal) getName() string {
+func (val *AMQPVal) getName() string {
 	if val.QueueName != "" {
 		return val.QueueName
 	}

--- a/executors/http_executor.go
+++ b/executors/http_executor.go
@@ -20,7 +20,7 @@ type HTTPVal struct {
 }
 
 // DoExecute : Preparing to make a http call with request body
-func (httpVal HTTPVal) DoExecute(requestBody interface{}, prefix string) (interface{}, error) {
+func (httpVal *HTTPVal) DoExecute(requestBody interface{}, prefix string) (interface{}, error) {
 	log.Debugf("%s HTTP Executor: Calling http %s:%s body:%v", prefix, httpVal.Method, httpVal.URL, requestBody)
 	var httpClient = &http.Client{
 		Timeout: time.Second * 10,
@@ -49,7 +49,7 @@ func (httpVal HTTPVal) DoExecute(requestBody interface{}, prefix string) (interf
 	return string(data), err
 }
 
-func fetchAndLoadRequestWithHeadersIfDefined(httpVal HTTPVal, request *http.Request) {
+func fetchAndLoadRequestWithHeadersIfDefined(httpVal *HTTPVal, request *http.Request) {
 	if httpVal.Headers != "" {
 		httpHeaders := strings.Split(httpVal.Headers, ";")
 		for _, header := range httpHeaders[:len(httpHeaders)-1] {

--- a/executors/kafka_executor.go
+++ b/executors/kafka_executor.go
@@ -16,7 +16,7 @@ type KafkaVal struct {
 }
 
 // DoExecute : Connecting to Kakfa URL and producing a message to Topic
-func (val KafkaVal) DoExecute(requestBody interface{}, prefix string) (interface{}, error) {
+func (val *KafkaVal) DoExecute(requestBody interface{}, prefix string) (interface{}, error) {
 	log.Debugf("%s Kafka Executor: Executing kafka %s body:%v", prefix, val.TopicName, requestBody)
 	syncProducer, err := sarama.NewSyncProducer([]string{val.ConnectionURL}, nil)
 	//asyncProducer, err := sarama.NewAsyncProducer([]string{val.ConnectionURL}, nil)

--- a/handlers/http.go
+++ b/handlers/http.go
@@ -36,7 +36,7 @@ func setupRouter() *gin.Engine {
 	return r
 }
 
-//LoadHTTPRoutes loads all the http endpoints that clamp exposes.This function is executed automatically during application startup
+// LoadHTTPRoutes loads all the http endpoints that clamp exposes.This function is executed automatically during application startup
 func LoadHTTPRoutes() {
 	r := setupRouter()
 	err := r.Run()

--- a/handlers/service_request_handler.go
+++ b/handlers/service_request_handler.go
@@ -178,7 +178,8 @@ func findServiceRequestByWorkflowNameHandler() gin.HandlerFunc {
 	}
 }
 
-func prepareServiceRequestsResponse(serviceRequests []*models.ServiceRequest, pageNumber int, pageSize int) models.ServiceRequestPageResponse {
+func prepareServiceRequestsResponse(
+	serviceRequests []*models.ServiceRequest, pageNumber int, pageSize int) models.ServiceRequestPageResponse {
 	response := models.ServiceRequestPageResponse{
 		ServiceRequests: serviceRequests,
 		PageNumber:      pageNumber,

--- a/handlers/service_request_handler.go
+++ b/handlers/service_request_handler.go
@@ -93,7 +93,7 @@ func readRequestHeadersAndSetInServiceRequest(c *gin.Context) string {
 	return serviceRequestHeaders
 }
 
-func prepareServiceRequestResponse(serviceReq models.ServiceRequest) models.ServiceRequestResponse {
+func prepareServiceRequestResponse(serviceReq *models.ServiceRequest) models.ServiceRequestResponse {
 	response := models.ServiceRequestResponse{
 		URL:    "/serviceRequest/" + serviceReq.ID.String(),
 		Status: serviceReq.Status,
@@ -178,7 +178,7 @@ func findServiceRequestByWorkflowNameHandler() gin.HandlerFunc {
 	}
 }
 
-func prepareServiceRequestsResponse(serviceRequests []models.ServiceRequest, pageNumber int, pageSize int) models.ServiceRequestPageResponse {
+func prepareServiceRequestsResponse(serviceRequests []*models.ServiceRequest, pageNumber int, pageSize int) models.ServiceRequestPageResponse {
 	response := models.ServiceRequestPageResponse{
 		ServiceRequests: serviceRequests,
 		PageNumber:      pageNumber,

--- a/handlers/service_request_handler.go
+++ b/handlers/service_request_handler.go
@@ -85,7 +85,7 @@ func readRequestHeadersAndSetInServiceRequest(c *gin.Context) string {
 	for key, value := range c.Request.Header {
 		serviceRequestHeaders += key + ":" + value[0] + ";"
 	}
-	//Setting Request Headers if it exists
+	// Setting Request Headers if it exists
 	if serviceRequestHeaders != "" {
 		log.Debugf("Service Request Headers ====> %s", serviceRequestHeaders)
 		return serviceRequestHeaders
@@ -145,7 +145,7 @@ func getServiceRequestStatusHandler() gin.HandlerFunc {
 			return
 		}
 		stepsStatusResponse := services.PrepareStepStatusResponse(uuid.MustParse(serviceRequestID), workflow, stepsStatues)
-		//TODO - handle error scenario. Currently it is always 200 ok
+		// TODO - handle error scenario. Currently it is always 200 ok
 		serviceRequestByIDHistogram.Observe(time.Since(startTime).Seconds())
 		c.JSON(http.StatusOK, stepsStatusResponse)
 	}

--- a/handlers/service_request_handler_test.go
+++ b/handlers/service_request_handler_test.go
@@ -143,7 +143,7 @@ func CreateWorkflowIfItsAlreadyDoesNotExists() {
 	resp, err := services.FindWorkflowByName(workflowName)
 	log.Println(resp)
 	if err != nil {
-		services.SaveWorkflow(workflow)
+		services.SaveWorkflow(&workflow)
 	}
 }
 
@@ -182,7 +182,7 @@ func createWorkflowWithTransformationEnabledInOneStep() {
 	resp, err := services.FindWorkflowByName(transformationWorkflowName)
 	log.Println(resp)
 	if err != nil {
-		services.SaveWorkflow(workflow)
+		services.SaveWorkflow(&workflow)
 	}
 }
 

--- a/handlers/step_response_handler.go
+++ b/handlers/step_response_handler.go
@@ -49,7 +49,7 @@ func createStepResponseHandler() gin.HandlerFunc {
 		res.RequestHeaders = resumeServiceRequestHeaders
 		log.Debugf("[HTTP Consumer] : Received step completed response: %v", res)
 		log.Debug("[HTTP Consumer] : Pushing step completed response to channel")
-		services.AddStepResponseToResumeChannel(res)
+		services.AddStepResponseToResumeChannel(&res)
 		resumeAsyncServiceRequestHistogram.Observe(time.Since(startTime).Seconds())
 		c.JSON(http.StatusOK, models.CreateSuccessResponse(http.StatusOK, "success"))
 	}

--- a/handlers/workflow_handler.go
+++ b/handlers/workflow_handler.go
@@ -76,7 +76,7 @@ func createWorkflowHandler() gin.HandlerFunc {
 			return
 		}
 		log.Debugf("Create workflow request : %v", workflowReq)
-		serviceFlowRes := models.CreateWorkflow(workflowReq)
+		serviceFlowRes := models.CreateWorkflow(&workflowReq)
 		serviceFlowRes, err = services.SaveWorkflow(serviceFlowRes)
 		workflowRequestHistogram.Observe(time.Since(startTime).Seconds())
 		if err != nil {

--- a/handlers/workflow_handler.go
+++ b/handlers/workflow_handler.go
@@ -153,7 +153,7 @@ func getWorkflows() gin.HandlerFunc {
 }
 
 func prepareWorkflowResponse(
-	workflows []models.Workflow, pageNumber int, pageSize int, totalWorkflowsCount int) models.WorkflowsPageResponse {
+	workflows []*models.Workflow, pageNumber int, pageSize int, totalWorkflowsCount int) models.WorkflowsPageResponse {
 	response := models.WorkflowsPageResponse{
 		Workflows:           workflows,
 		PageNumber:          pageNumber,

--- a/listeners/amqp_listener.go
+++ b/listeners/amqp_listener.go
@@ -66,7 +66,7 @@ func (amqpListener amqpListener) Listen() {
 					}
 					log.Debugf("[AMQP Consumer] : Received step completed response: %v", res)
 					log.Debug("[AMQP Consumer] : Pushing step completed response to channel")
-					services.AddStepResponseToResumeChannel(res)
+					services.AddStepResponseToResumeChannel(&res)
 				}
 			}
 		}()

--- a/listeners/kafka_consumer_listener.go
+++ b/listeners/kafka_consumer_listener.go
@@ -61,7 +61,7 @@ func (c *Consumer) Listen() {
 						}
 						log.Debugf("[Kafka Consumer] : Received step completed response: %v", res)
 						log.Debug("[Kafka Consumer] : Pushing step completed response to channel")
-						services.AddStepResponseToResumeChannel(res)
+						services.AddStepResponseToResumeChannel(&res)
 					}
 				case consumerError := <-errors:
 					msgCount++

--- a/models/service_request.go
+++ b/models/service_request.go
@@ -19,9 +19,9 @@ type ServiceRequest struct {
 	RequestHeaders string
 }
 
-func NewServiceRequest(workflowName string, payload map[string]interface{}) ServiceRequest {
+func NewServiceRequest(workflowName string, payload map[string]interface{}) *ServiceRequest {
 	currentTime := time.Now()
-	return ServiceRequest{ID: uuid.New(), WorkflowName: workflowName, Status: StatusNew, CreatedAt: currentTime, Payload: payload}
+	return &ServiceRequest{ID: uuid.New(), WorkflowName: workflowName, Status: StatusNew, CreatedAt: currentTime, Payload: payload}
 }
 
 type PGServiceRequest struct {
@@ -33,8 +33,8 @@ type PGServiceRequest struct {
 	Payload      map[string]interface{} `json:"payload"`
 }
 
-func (serviceReq ServiceRequest) ToPgServiceRequest() PGServiceRequest {
-	return PGServiceRequest{
+func (serviceReq *ServiceRequest) ToPgServiceRequest() *PGServiceRequest {
+	return &PGServiceRequest{
 		ID:           serviceReq.ID,
 		WorkflowName: serviceReq.WorkflowName,
 		Status:       serviceReq.Status,
@@ -43,8 +43,8 @@ func (serviceReq ServiceRequest) ToPgServiceRequest() PGServiceRequest {
 	}
 }
 
-func (pgServReq PGServiceRequest) ToServiceRequest() ServiceRequest {
-	return ServiceRequest{
+func (pgServReq *PGServiceRequest) ToServiceRequest() *ServiceRequest {
+	return &ServiceRequest{
 		ID:           pgServReq.ID,
 		WorkflowName: pgServReq.WorkflowName,
 		Status:       pgServReq.Status,

--- a/models/service_request_page_response.go
+++ b/models/service_request_page_response.go
@@ -1,7 +1,7 @@
 package models
 
 type ServiceRequestPageResponse struct {
-	ServiceRequests []ServiceRequest `json:"serviceRequests"`
-	PageNumber      int              `json:"pageNumber"`
-	PageSize        int              `json:"pageSize"`
+	ServiceRequests []*ServiceRequest `json:"serviceRequests"`
+	PageNumber      int               `json:"pageNumber"`
+	PageSize        int               `json:"pageSize"`
 }

--- a/models/step.go
+++ b/models/step.go
@@ -175,10 +175,10 @@ func (step *Step) setMode(mode interface{}) error {
 	return nil
 }
 
-func (step Step) getHTTPVal() executors.HTTPVal {
+func (step *Step) getHTTPVal() executors.HTTPVal {
 	return step.Val.(executors.HTTPVal)
 }
 
-func (step Step) getAMQPVal() *executors.AMQPVal {
+func (step *Step) getAMQPVal() *executors.AMQPVal {
 	return step.Val.(*executors.AMQPVal)
 }

--- a/models/step_status.go
+++ b/models/step_status.go
@@ -26,8 +26,8 @@ type StepsStatus struct {
 	StepID           int       `json:"step_id"`
 }
 
-func NewStepsStatus(stepStatus StepsStatus) StepsStatus {
-	return StepsStatus{
+func NewStepsStatus(stepStatus *StepsStatus) *StepsStatus {
+	return &StepsStatus{
 		ID:               stepStatus.ID,
 		ServiceRequestID: stepStatus.ServiceRequestID,
 		WorkflowName:     stepStatus.WorkflowName,
@@ -40,7 +40,7 @@ func NewStepsStatus(stepStatus StepsStatus) StepsStatus {
 }
 
 // CreateStepsStatus : Entry for a given service request id and return step status details
-func CreateStepsStatus(stepStatus StepsStatus) StepsStatus {
+func CreateStepsStatus(stepStatus *StepsStatus) *StepsStatus {
 	return NewStepsStatus(stepStatus)
 }
 
@@ -58,8 +58,8 @@ type PGStepStatus struct {
 	StepID           int
 }
 
-func (stepStatus StepsStatus) ToPgStepStatus() PGStepStatus {
-	return PGStepStatus{
+func (stepStatus *StepsStatus) ToPgStepStatus() *PGStepStatus {
+	return &PGStepStatus{
 		ID:               stepStatus.ID,
 		ServiceRequestID: stepStatus.ServiceRequestID,
 		WorkflowName:     stepStatus.WorkflowName,
@@ -73,8 +73,8 @@ func (stepStatus StepsStatus) ToPgStepStatus() PGStepStatus {
 	}
 }
 
-func (pgStepStatus PGStepStatus) ToStepStatus() StepsStatus {
-	return StepsStatus{
+func (pgStepStatus *PGStepStatus) ToStepStatus() *StepsStatus {
+	return &StepsStatus{
 		ID:               pgStepStatus.ID,
 		ServiceRequestID: pgStepStatus.ServiceRequestID,
 		WorkflowName:     pgStepStatus.WorkflowName,

--- a/models/step_status_test.go
+++ b/models/step_status_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestShouldCreateANewStepStatus(t *testing.T) {
-	stepStatusRequest := StepsStatus{
+	stepStatusRequest := &StepsStatus{
 		ID:               "1",
 		ServiceRequestID: uuid.New(),
 		WorkflowName:     "testWF",

--- a/models/workflow.go
+++ b/models/workflow.go
@@ -63,8 +63,8 @@ type PGWorkflow struct {
 
 // ToPGWorkflow converts a Workflow object into a Postgres specific workflow structure that is used for persisting
 // to postgres specifically
-func (workflow Workflow) ToPGWorkflow() PGWorkflow {
-	return PGWorkflow{
+func (workflow *Workflow) ToPGWorkflow() *PGWorkflow {
+	return &PGWorkflow{
 		ID:          workflow.ID,
 		Name:        workflow.Name,
 		Description: workflow.Description,
@@ -77,8 +77,8 @@ func (workflow Workflow) ToPGWorkflow() PGWorkflow {
 
 // ToWorkflow converts a PGWorkflow struct to a Workflow structure that is used in the application to pass around
 // a workflow definition.
-func (pgWorkflow PGWorkflow) ToWorkflow() Workflow {
-	return Workflow{
+func (pgWorkflow *PGWorkflow) ToWorkflow() *Workflow {
+	return &Workflow{
 		ID:          pgWorkflow.ID,
 		Name:        pgWorkflow.Name,
 		Description: pgWorkflow.Description,
@@ -93,7 +93,7 @@ func (pgWorkflow PGWorkflow) ToWorkflow() Workflow {
 // and can be triggered. Once a workflow has been created it is not possible to change/edit it currently. During creation
 // each step is assigned an id, which is unique to the workflow, a type and a reply to queue name for Kafka and AMQP
 // to ensure that for async channels a reply channel is set during workflow creation.
-func CreateWorkflow(workflowRequest Workflow) Workflow {
+func CreateWorkflow(workflowRequest Workflow) *Workflow {
 	stepCount := 0
 	for i := 0; i < len(workflowRequest.Steps); i++ {
 		stepCount++
@@ -101,7 +101,7 @@ func CreateWorkflow(workflowRequest Workflow) Workflow {
 		workflowRequest.Steps[i] = stepEnrichmentMap[stepTypeName](workflowRequest.Steps[i], stepCount)
 		updateStepCounterForEachOfSubSteps(workflowRequest, i, stepCount)
 	}
-	return newServiceFlow(workflowRequest)
+	return newServiceFlow(&workflowRequest)
 }
 
 func updateStepCounterForEachOfSubSteps(workflowRequest Workflow, i int, stepCount int) {
@@ -119,8 +119,8 @@ func updateSubStepsIds(workflowRequest Workflow, i int, stepCount int) int {
 	return stepCount
 }
 
-func newServiceFlow(workflow Workflow) Workflow {
-	return Workflow{
+func newServiceFlow(workflow *Workflow) *Workflow {
+	return &Workflow{
 		ID:          workflow.ID,
 		Name:        workflow.Name,
 		Description: workflow.Description,

--- a/models/workflow_test.go
+++ b/models/workflow_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin/binding"
 
@@ -252,4 +253,80 @@ func TestShouldCreateNewWorkflowWithOnFailureSteps(t *testing.T) {
 	assert.Equal(t, "onFailureStep", workflowResponse.Steps[0].OnFailure[0].Name)
 	assert.Equal(t, utils.StepModeHTTP, workflowResponse.Steps[0].OnFailure[0].Mode)
 	assert.Equal(t, "https://run.mocky.io/v3/0590fbf8-0f1c-401c-b9df-65e98ef0385d", workflowResponse.Steps[0].OnFailure[0].getHTTPVal().URL)
+}
+
+func TestWorkflowStepIDAreSequentiallyIncrementing(t *testing.T) {
+	w := CreateWorkflow(Workflow{
+		ID:          "abc",
+		Name:        "WorkflowABC",
+		Description: "Workflow ABC",
+		Enabled:     true,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+		Steps: []Step{
+			{
+				ID:             0,
+				Name:           "Step1",
+				Mode:           utils.StepModeHTTP,
+				Enabled:        true,
+				canStepExecute: true,
+				OnFailure: []Step{
+					{
+						ID:             0,
+						Name:           "OnFailureStep1",
+						Mode:           utils.StepModeHTTP,
+						Enabled:        true,
+						canStepExecute: true,
+					},
+					{
+						ID:             0,
+						Name:           "OnFailureStep2",
+						Mode:           utils.StepModeHTTP,
+						Enabled:        true,
+						canStepExecute: true,
+					},
+				},
+			},
+			{
+				ID:             0,
+				Name:           "Step2",
+				Mode:           utils.StepModeHTTP,
+				Enabled:        true,
+				canStepExecute: true,
+				OnFailure: []Step{
+					{
+						ID:             0,
+						Name:           "OnFailureStep1",
+						Mode:           utils.StepModeHTTP,
+						Enabled:        true,
+						canStepExecute: true,
+					},
+					{
+						ID:             0,
+						Name:           "OnFailureStep2",
+						Mode:           utils.StepModeHTTP,
+						Enabled:        true,
+						canStepExecute: true,
+					},
+				},
+			},
+			{
+				ID:             0,
+				Name:           "Step2",
+				Mode:           utils.StepModeHTTP,
+				Enabled:        true,
+				canStepExecute: true,
+			},
+		},
+	})
+
+	assert.Equal(t, 1, w.Steps[0].ID)
+	assert.Equal(t, 2, w.Steps[0].OnFailure[0].ID)
+	assert.Equal(t, 3, w.Steps[0].OnFailure[1].ID)
+
+	assert.Equal(t, 4, w.Steps[1].ID)
+	assert.Equal(t, 5, w.Steps[1].OnFailure[0].ID)
+	assert.Equal(t, 6, w.Steps[1].OnFailure[1].ID)
+
+	assert.Equal(t, 7, w.Steps[2].ID)
 }

--- a/models/workflow_test.go
+++ b/models/workflow_test.go
@@ -42,7 +42,7 @@ func TestShouldCreateANewWorkflow(t *testing.T) {
 		log.Println(err)
 	}
 	assert.Nil(t, err)
-	workflowResponse := CreateWorkflow(serviceFlowRequest)
+	workflowResponse := CreateWorkflow(&serviceFlowRequest)
 
 	assert.NotEmpty(t, workflowResponse.ID)
 	assert.NotNil(t, workflowResponse.CreatedAt)
@@ -194,7 +194,7 @@ func TestIfReplyToQueueNameIsNotProvidedAsPartOfWorkflowRequestShouldReadDefault
 		log.Println(err)
 	}
 	assert.Nil(t, err)
-	workflowResponse := CreateWorkflow(serviceFlowRequest)
+	workflowResponse := CreateWorkflow(&serviceFlowRequest)
 
 	assert.NotEmpty(t, workflowResponse.ID)
 	assert.NotNil(t, workflowResponse.CreatedAt)
@@ -241,7 +241,7 @@ func TestShouldCreateNewWorkflowWithOnFailureSteps(t *testing.T) {
 		log.Println(err)
 	}
 	assert.Nil(t, err)
-	workflowResponse := CreateWorkflow(serviceFlowRequest)
+	workflowResponse := CreateWorkflow(&serviceFlowRequest)
 
 	assert.NotEmpty(t, workflowResponse.ID)
 	assert.NotNil(t, workflowResponse.CreatedAt)
@@ -256,7 +256,7 @@ func TestShouldCreateNewWorkflowWithOnFailureSteps(t *testing.T) {
 }
 
 func TestWorkflowStepIDAreSequentiallyIncrementing(t *testing.T) {
-	w := CreateWorkflow(Workflow{
+	w := CreateWorkflow(&Workflow{
 		ID:          "abc",
 		Name:        "WorkflowABC",
 		Description: "Workflow ABC",

--- a/models/workflows_page_response.go
+++ b/models/workflows_page_response.go
@@ -1,8 +1,8 @@
 package models
 
 type WorkflowsPageResponse struct {
-	Workflows           []Workflow `json:"workflows"`
-	PageNumber          int        `json:"pageNumber"`
-	PageSize            int        `json:"pageSize"`
-	TotalWorkflowsCount int        `json:"totalWorkflowsCount"`
+	Workflows           []*Workflow `json:"workflows"`
+	PageNumber          int         `json:"pageNumber"`
+	PageSize            int         `json:"pageSize"`
+	TotalWorkflowsCount int         `json:"totalWorkflowsCount"`
 }

--- a/repository/db.go
+++ b/repository/db.go
@@ -9,18 +9,18 @@ import (
 
 // DBInterface provides a collection of method signatures that needs to be implemented for a specific database.
 type DBInterface interface {
-	SaveServiceRequest(models.ServiceRequest) (models.ServiceRequest, error)
-	FindServiceRequestByID(uuid.UUID) (models.ServiceRequest, error)
-	SaveWorkflow(models.Workflow) (models.Workflow, error)
-	FindWorkflowByName(string) (models.Workflow, error)
-	SaveStepStatus(models.StepsStatus) (models.StepsStatus, error)
-	FindStepStatusByServiceRequestID(serviceRequestID uuid.UUID) ([]models.StepsStatus, error)
-	FindStepStatusByServiceRequestIDAndStatus(serviceRequestID uuid.UUID, status models.Status) ([]models.StepsStatus, error)
+	SaveServiceRequest(*models.ServiceRequest) (*models.ServiceRequest, error)
+	FindServiceRequestByID(uuid.UUID) (*models.ServiceRequest, error)
+	SaveWorkflow(*models.Workflow) (*models.Workflow, error)
+	FindWorkflowByName(string) (*models.Workflow, error)
+	SaveStepStatus(*models.StepsStatus) (*models.StepsStatus, error)
+	FindStepStatusByServiceRequestID(serviceRequestID uuid.UUID) ([]*models.StepsStatus, error)
+	FindStepStatusByServiceRequestIDAndStatus(serviceRequestID uuid.UUID, status models.Status) ([]*models.StepsStatus, error)
 	FindStepStatusByServiceRequestIDAndStepIDAndStatus(
-		serviceRequestID uuid.UUID, stepID int, status models.Status) (models.StepsStatus, error)
-	FindAllStepStatusByServiceRequestIDAndStepID(serviceRequestID uuid.UUID, stepID int) ([]models.StepsStatus, error)
-	GetWorkflows(pageNumber int, pageSize int, sortBy models.SortByFields) ([]models.Workflow, int, error)
-	FindServiceRequestsByWorkflowName(workflowName string, pageNumber int, pageSize int) ([]models.ServiceRequest, error)
+		serviceRequestID uuid.UUID, stepID int, status models.Status) (*models.StepsStatus, error)
+	FindAllStepStatusByServiceRequestIDAndStepID(serviceRequestID uuid.UUID, stepID int) ([]*models.StepsStatus, error)
+	GetWorkflows(pageNumber int, pageSize int, sortBy models.SortByFields) ([]*models.Workflow, int, error)
+	FindServiceRequestsByWorkflowName(workflowName string, pageNumber int, pageSize int) ([]*models.ServiceRequest, error)
 	DeleteWorkflowByName(string) error
 	Ping() error
 }

--- a/repository/postgres.go
+++ b/repository/postgres.go
@@ -113,7 +113,7 @@ func (p *postgres) FindStepStatusByServiceRequestIDAndStatus(
 	serviceRequestID uuid.UUID, status models.Status) ([]*models.StepsStatus, error) {
 	var pgStepStatus []models.PGStepStatus
 	var stepStatuses []*models.StepsStatus
-	err := p.getDb().Model(&pgStepStatus).Where("service_request_id = ? and status = ?", serviceRequestID, status).Order("created_at ASC").Select()
+	err := p.getDB().Model(&pgStepStatus).Where("service_request_id = ? and status = ?", serviceRequestID, status).Order("created_at ASC").Select()
 	if err != nil {
 		return stepStatuses, err
 	}

--- a/repository/postgres.go
+++ b/repository/postgres.go
@@ -113,12 +113,13 @@ func (p *postgres) FindStepStatusByServiceRequestIDAndStatus(
 	serviceRequestID uuid.UUID, status models.Status) ([]*models.StepsStatus, error) {
 	var pgStepStatus []models.PGStepStatus
 	var stepStatuses []*models.StepsStatus
-	err := p.getDB().Model(&pgStepStatus).Where("service_request_id = ? and status = ?", serviceRequestID, status).Order("created_at ASC").Select()
+	err := p.getDB().Model(&pgStepStatus).Where("service_request_id = ? and status = ?", serviceRequestID, status).
+		Order("created_at ASC").Select()
 	if err != nil {
 		return stepStatuses, err
 	}
-	for _, status := range pgStepStatus {
-		stepStatuses = append(stepStatuses, status.ToStepStatus())
+	for i := range pgStepStatus {
+		stepStatuses = append(stepStatuses, pgStepStatus[i].ToStepStatus())
 	}
 	return stepStatuses, err
 }
@@ -128,8 +129,8 @@ func (p *postgres) FindStepStatusByServiceRequestID(serviceRequestID uuid.UUID) 
 	err := p.getDB().Model(&pgStepStatus).Where("service_request_id = ?", serviceRequestID).Order("created_at ASC").Select()
 	var stepStatuses []*models.StepsStatus
 	if err == nil {
-		for _, status := range pgStepStatus {
-			stepStatuses = append(stepStatuses, status.ToStepStatus())
+		for i := range pgStepStatus {
+			stepStatuses = append(stepStatuses, pgStepStatus[i].ToStepStatus())
 		}
 	}
 	return stepStatuses, err
@@ -194,8 +195,8 @@ func (p *postgres) GetWorkflows(pageNumber int, pageSize int, sortFields models.
 		return []*models.Workflow{}, 0, err
 	}
 	var workflows []*models.Workflow
-	for _, pgWorkflow := range pgWorkflows {
-		workflows = append(workflows, pgWorkflow.ToWorkflow())
+	for i := range pgWorkflows {
+		workflows = append(workflows, pgWorkflows[i].ToWorkflow())
 	}
 	return workflows, totalWorkflowsCount, err
 }

--- a/repository/postgres.go
+++ b/repository/postgres.go
@@ -69,14 +69,14 @@ type postgres struct {
 	db *pg.DB
 }
 
-func (p *postgres) FindServiceRequestsByWorkflowName(workflowName string, pageNumber int, pageSize int) ([]models.ServiceRequest, error) {
+func (p *postgres) FindServiceRequestsByWorkflowName(workflowName string, pageNumber int, pageSize int) ([]*models.ServiceRequest, error) {
 	var pgServiceRequests []models.PGServiceRequest
 	err := p.getDB().Model(&pgServiceRequests).
 		Where("workflow_name = ?", workflowName).
 		Offset(pageSize * pageNumber).
 		Limit(pageSize).
 		Select()
-	var workflows []models.ServiceRequest
+	var workflows []*models.ServiceRequest
 	if err == nil {
 		for _, pgServiceRequest := range pgServiceRequests {
 			workflows = append(workflows, pgServiceRequest.ToServiceRequest())
@@ -85,36 +85,35 @@ func (p *postgres) FindServiceRequestsByWorkflowName(workflowName string, pageNu
 	return workflows, err
 }
 
-func (p *postgres) FindAllStepStatusByServiceRequestIDAndStepID(serviceRequestID uuid.UUID, stepID int) ([]models.StepsStatus, error) {
+func (p *postgres) FindAllStepStatusByServiceRequestIDAndStepID(serviceRequestID uuid.UUID, stepID int) ([]*models.StepsStatus, error) {
 	var pgStepStatus []models.PGStepStatus
 	err := p.getDB().Model(&pgStepStatus).Where("service_request_id = ? and step_id = ?", serviceRequestID, stepID).Select()
-	var stepStatuses []models.StepsStatus
+	var stepStatuses []*models.StepsStatus
 	if err == nil {
-		for _, status := range pgStepStatus {
-			stepStatuses = append(stepStatuses, status.ToStepStatus())
+		for i := range pgStepStatus {
+			stepStatuses = append(stepStatuses, pgStepStatus[i].ToStepStatus())
 		}
 	}
 	return stepStatuses, err
 }
 
 func (p *postgres) FindStepStatusByServiceRequestIDAndStepIDAndStatus(
-	serviceRequestID uuid.UUID, stepID int, status models.Status) (models.StepsStatus, error) {
+	serviceRequestID uuid.UUID, stepID int, status models.Status) (*models.StepsStatus, error) {
 	var pgStepStatus models.PGStepStatus
 	var stepStatuses models.StepsStatus
 	err := p.getDB().Model(&pgStepStatus).Where("service_request_id = ? and step_id = ? and status = ?",
 		serviceRequestID, stepID, status).Select()
 	if err != nil {
-		return stepStatuses, err
+		return &stepStatuses, err
 	}
 	return pgStepStatus.ToStepStatus(), err
 }
 
 func (p *postgres) FindStepStatusByServiceRequestIDAndStatus(
-	serviceRequestID uuid.UUID, status models.Status) ([]models.StepsStatus, error) {
+	serviceRequestID uuid.UUID, status models.Status) ([]*models.StepsStatus, error) {
 	var pgStepStatus []models.PGStepStatus
-	var stepStatuses []models.StepsStatus
-	err := p.getDB().Model(&pgStepStatus).Where(
-		"service_request_id = ? and status = ?", serviceRequestID, status).Order("created_at ASC").Select()
+	var stepStatuses []*models.StepsStatus
+	err := p.getDb().Model(&pgStepStatus).Where("service_request_id = ? and status = ?", serviceRequestID, status).Order("created_at ASC").Select()
 	if err != nil {
 		return stepStatuses, err
 	}
@@ -124,10 +123,10 @@ func (p *postgres) FindStepStatusByServiceRequestIDAndStatus(
 	return stepStatuses, err
 }
 
-func (p *postgres) FindStepStatusByServiceRequestID(serviceRequestID uuid.UUID) ([]models.StepsStatus, error) {
+func (p *postgres) FindStepStatusByServiceRequestID(serviceRequestID uuid.UUID) ([]*models.StepsStatus, error) {
 	var pgStepStatus []models.PGStepStatus
 	err := p.getDB().Model(&pgStepStatus).Where("service_request_id = ?", serviceRequestID).Order("created_at ASC").Select()
-	var stepStatuses []models.StepsStatus
+	var stepStatuses []*models.StepsStatus
 	if err == nil {
 		for _, status := range pgStepStatus {
 			stepStatuses = append(stepStatuses, status.ToStepStatus())
@@ -136,13 +135,13 @@ func (p *postgres) FindStepStatusByServiceRequestID(serviceRequestID uuid.UUID) 
 	return stepStatuses, err
 }
 
-func (p *postgres) SaveStepStatus(stepStatus models.StepsStatus) (models.StepsStatus, error) {
+func (p *postgres) SaveStepStatus(stepStatus *models.StepsStatus) (*models.StepsStatus, error) {
 	pgStepStatusReq := stepStatus.ToPgStepStatus()
-	err := p.getDB().Insert(&pgStepStatusReq)
+	err := p.getDB().Insert(pgStepStatusReq)
 	return pgStepStatusReq.ToStepStatus(), err
 }
 
-func (p *postgres) FindWorkflowByName(workflowName string) (models.Workflow, error) {
+func (p *postgres) FindWorkflowByName(workflowName string) (*models.Workflow, error) {
 	pgWorkflow := new(models.PGWorkflow)
 	err := p.getDB().Model(pgWorkflow).Where("name = ?", workflowName).Select()
 	return pgWorkflow.ToWorkflow(), err
@@ -153,14 +152,14 @@ func (p *postgres) DeleteWorkflowByName(workflowName string) error {
 	return err
 }
 
-func (p *postgres) SaveWorkflow(workflowReq models.Workflow) (models.Workflow, error) {
+func (p *postgres) SaveWorkflow(workflowReq *models.Workflow) (*models.Workflow, error) {
 	pgWorkflow := workflowReq.ToPGWorkflow()
 	log.Debugf("pgworfklow: %v", pgWorkflow)
-	err := p.getDB().Insert(&pgWorkflow)
+	err := p.getDB().Insert(pgWorkflow)
 	return pgWorkflow.ToWorkflow(), err
 }
 
-func (p *postgres) FindServiceRequestByID(serviceRequestID uuid.UUID) (models.ServiceRequest, error) {
+func (p *postgres) FindServiceRequestByID(serviceRequestID uuid.UUID) (*models.ServiceRequest, error) {
 	pgServiceRequest := &models.PGServiceRequest{ID: serviceRequestID}
 	err := p.getDB().Select(pgServiceRequest)
 	if err != nil {
@@ -169,20 +168,20 @@ func (p *postgres) FindServiceRequestByID(serviceRequestID uuid.UUID) (models.Se
 	return pgServiceRequest.ToServiceRequest(), err
 }
 
-func (p *postgres) SaveServiceRequest(serviceReq models.ServiceRequest) (models.ServiceRequest, error) {
+func (p *postgres) SaveServiceRequest(serviceReq *models.ServiceRequest) (*models.ServiceRequest, error) {
 	pgServReq := serviceReq.ToPgServiceRequest()
 	db := p.getDB()
-	err := db.Insert(&pgServReq)
+	err := db.Insert(pgServReq)
 	return pgServReq.ToServiceRequest(), err
 }
 
-func (p *postgres) GetWorkflows(pageNumber int, pageSize int, sortFields models.SortByFields) ([]models.Workflow, int, error) {
+func (p *postgres) GetWorkflows(pageNumber int, pageSize int, sortFields models.SortByFields) ([]*models.Workflow, int, error) {
 	var pgWorkflows []models.PGWorkflow
 	query := p.getDB().Model(&pgWorkflows)
 	for _, sortField := range sortFields {
 		reference, found := keyReferences[sortField.Key]
 		if !found {
-			return []models.Workflow{}, 0, errors.New("undefined key reference used")
+			return []*models.Workflow{}, 0, errors.New("undefined key reference used")
 		}
 		order := sortField.Order
 		if found {
@@ -192,9 +191,9 @@ func (p *postgres) GetWorkflows(pageNumber int, pageSize int, sortFields models.
 	totalWorkflowsCount, err := query.Offset(pageSize * (pageNumber - 1)).
 		Limit(pageSize).SelectAndCount()
 	if err != nil {
-		return []models.Workflow{}, 0, err
+		return []*models.Workflow{}, 0, err
 	}
-	var workflows []models.Workflow
+	var workflows []*models.Workflow
 	for _, pgWorkflow := range pgWorkflows {
 		workflows = append(workflows, pgWorkflow.ToWorkflow())
 	}

--- a/services/abstract_test.go
+++ b/services/abstract_test.go
@@ -13,65 +13,65 @@ func (m mockDB) DeleteWorkflowByName(workflowName string) error {
 	return deleteWorkflowByNameMock(workflowName)
 }
 
-func (m mockDB) FindServiceRequestsByWorkflowName(workflowName string, pageNumber int, pageSize int) ([]models.ServiceRequest, error) {
+func (m mockDB) FindServiceRequestsByWorkflowName(workflowName string, pageNumber int, pageSize int) ([]*models.ServiceRequest, error) {
 	return findServiceRequestsByWorkflowName(workflowName, pageNumber, pageSize)
 }
 
-func (m mockDB) GetWorkflows(pageNumber int, pageSize int, sortBy models.SortByFields) ([]models.Workflow, int, error) {
+func (m mockDB) GetWorkflows(pageNumber int, pageSize int, sortBy models.SortByFields) ([]*models.Workflow, int, error) {
 	return getWorkflowsMock(pageNumber, pageSize, sortBy)
 }
 
-func (m mockDB) FindStepStatusByServiceRequestIDAndStepIDAndStatus(serviceRequestID uuid.UUID, stepID int, status models.Status) (models.StepsStatus, error) {
+func (m mockDB) FindStepStatusByServiceRequestIDAndStepIDAndStatus(serviceRequestID uuid.UUID, stepID int, status models.Status) (*models.StepsStatus, error) {
 	return findStepStatusByServiceRequestIDAndStepIDAndStatusMock(serviceRequestID, stepID, status)
 }
 
-func (m mockDB) FindStepStatusByServiceRequestIDAndStepNameAndStatus(serviceRequestID uuid.UUID, stepName string, status models.Status) (models.StepsStatus, error) {
+func (m mockDB) FindStepStatusByServiceRequestIDAndStepNameAndStatus(serviceRequestID uuid.UUID, stepName string, status models.Status) (*models.StepsStatus, error) {
 	return findStepStatusByServiceRequestIDAndStepNameAndStatusMock(serviceRequestID, stepName, status)
 }
 
-var findServiceRequestsByWorkflowName func(workflowName string, pageNumber int, pageSize int) ([]models.ServiceRequest, error)
-var saveServiceRequestMock func(serReq models.ServiceRequest) (models.ServiceRequest, error)
-var saveStepStatusMock func(stepStatus models.StepsStatus) (models.StepsStatus, error)
-var SaveWorkflowMock func(workflow models.Workflow) (models.Workflow, error)
-var findServiceRequestByIDMock func(uuid.UUID) (models.ServiceRequest, error)
-var findWorkflowByNameMock func(workflowName string) (models.Workflow, error)
-var findStepStatusByServiceRequestIDMock func(serviceRequestID uuid.UUID) ([]models.StepsStatus, error)
-var findStepStatusByServiceRequestIDAndStatusMock func(serviceRequestID uuid.UUID, status models.Status) ([]models.StepsStatus, error)
-var findAllStepStatusByServiceRequestIDAndStepIDMock func(serviceRequestID uuid.UUID, stepID int) ([]models.StepsStatus, error)
-var findStepStatusByServiceRequestIDAndStepNameAndStatusMock func(serviceRequestID uuid.UUID, stepName string, status models.Status) (models.StepsStatus, error)
-var findStepStatusByServiceRequestIDAndStepIDAndStatusMock func(serviceRequestID uuid.UUID, stepID int, status models.Status) (models.StepsStatus, error)
-var getWorkflowsMock func(pageNumber int, pageSize int, sortBy models.SortByFields) ([]models.Workflow, int, error)
+var findServiceRequestsByWorkflowName func(workflowName string, pageNumber int, pageSize int) ([]*models.ServiceRequest, error)
+var saveServiceRequestMock func(serReq *models.ServiceRequest) (*models.ServiceRequest, error)
+var saveStepStatusMock func(stepStatus *models.StepsStatus) (*models.StepsStatus, error)
+var SaveWorkflowMock func(workflow *models.Workflow) (*models.Workflow, error)
+var findServiceRequestByIDMock func(uuid.UUID) (*models.ServiceRequest, error)
+var findWorkflowByNameMock func(workflowName string) (*models.Workflow, error)
+var findStepStatusByServiceRequestIDMock func(serviceRequestID uuid.UUID) ([]*models.StepsStatus, error)
+var findStepStatusByServiceRequestIDAndStatusMock func(serviceRequestID uuid.UUID, status models.Status) ([]*models.StepsStatus, error)
+var findAllStepStatusByServiceRequestIDAndStepIDMock func(serviceRequestID uuid.UUID, stepID int) ([]*models.StepsStatus, error)
+var findStepStatusByServiceRequestIDAndStepNameAndStatusMock func(serviceRequestID uuid.UUID, stepName string, status models.Status) (*models.StepsStatus, error)
+var findStepStatusByServiceRequestIDAndStepIDAndStatusMock func(serviceRequestID uuid.UUID, stepID int, status models.Status) (*models.StepsStatus, error)
+var getWorkflowsMock func(pageNumber int, pageSize int, sortBy models.SortByFields) ([]*models.Workflow, int, error)
 var deleteWorkflowByNameMock func(workflowName string) error
 
-func (m mockDB) SaveServiceRequest(serReq models.ServiceRequest) (models.ServiceRequest, error) {
+func (m mockDB) SaveServiceRequest(serReq *models.ServiceRequest) (*models.ServiceRequest, error) {
 	return saveServiceRequestMock(serReq)
 }
 
-func (m mockDB) FindServiceRequestByID(id uuid.UUID) (models.ServiceRequest, error) {
+func (m mockDB) FindServiceRequestByID(id uuid.UUID) (*models.ServiceRequest, error) {
 	return findServiceRequestByIDMock(id)
 }
 
-func (m mockDB) SaveWorkflow(workflow models.Workflow) (models.Workflow, error) {
+func (m mockDB) SaveWorkflow(workflow *models.Workflow) (*models.Workflow, error) {
 	return SaveWorkflowMock(workflow)
 }
 
-func (m mockDB) FindWorkflowByName(workflowName string) (models.Workflow, error) {
+func (m mockDB) FindWorkflowByName(workflowName string) (*models.Workflow, error) {
 	return findWorkflowByNameMock(workflowName)
 }
 
-func (m mockDB) SaveStepStatus(stepStatus models.StepsStatus) (models.StepsStatus, error) {
+func (m mockDB) SaveStepStatus(stepStatus *models.StepsStatus) (*models.StepsStatus, error) {
 	return saveStepStatusMock(stepStatus)
 }
 
-func (m mockDB) FindStepStatusByServiceRequestID(serviceRequestID uuid.UUID) ([]models.StepsStatus, error) {
+func (m mockDB) FindStepStatusByServiceRequestID(serviceRequestID uuid.UUID) ([]*models.StepsStatus, error) {
 	return findStepStatusByServiceRequestIDMock(serviceRequestID)
 }
 
-func (m mockDB) FindStepStatusByServiceRequestIDAndStatus(serviceRequestID uuid.UUID, status models.Status) ([]models.StepsStatus, error) {
+func (m mockDB) FindStepStatusByServiceRequestIDAndStatus(serviceRequestID uuid.UUID, status models.Status) ([]*models.StepsStatus, error) {
 	return findStepStatusByServiceRequestIDAndStatusMock(serviceRequestID, status)
 }
 
-func (m mockDB) FindAllStepStatusByServiceRequestIDAndStepID(serviceRequestID uuid.UUID, stepID int) ([]models.StepsStatus, error) {
+func (m mockDB) FindAllStepStatusByServiceRequestIDAndStepID(serviceRequestID uuid.UUID, stepID int) ([]*models.StepsStatus, error) {
 	return findAllStepStatusByServiceRequestIDAndStepIDMock(serviceRequestID, stepID)
 }
 

--- a/services/async_resume_worker.go
+++ b/services/async_resume_worker.go
@@ -44,7 +44,7 @@ func resumeSteps(workerID int, resumeStepsChannel <-chan models.AsyncStepRespons
 		prefix = fmt.Sprintf("%s [REQUEST_ID: %s]", prefix, stepResponse.ServiceRequestID)
 		log.Debugf("%s : Received step response : %v", prefix, stepResponse)
 		currentStepStatusArr, _ := FindAllStepStatusByServiceRequestIDAndStepID(stepResponse.ServiceRequestID, stepResponse.StepID)
-		var currentStepStatus models.StepsStatus
+		var currentStepStatus *models.StepsStatus
 		for _, stepStatus := range currentStepStatusArr {
 			if stepStatus.Status == models.StatusStarted {
 				currentStepStatus = stepStatus

--- a/services/async_resume_worker.go
+++ b/services/async_resume_worker.go
@@ -90,11 +90,11 @@ func getResumeStepResponseChannel() chan models.AsyncStepResponse {
 	return resumeStepsChannel
 }
 
-func AddStepResponseToResumeChannel(response models.AsyncStepResponse) {
+func AddStepResponseToResumeChannel(response *models.AsyncStepResponse) {
 	if response.ServiceRequestID == uuid.Nil || response.StepID == 0 || (response.Response == nil && response.Error.Code == 0) {
 		log.Errorf("Invalid step resume request received %v", response)
 		return
 	}
 	channel := getResumeStepResponseChannel()
-	channel <- response
+	channel <- *response
 }

--- a/services/async_resume_worker_test.go
+++ b/services/async_resume_worker_test.go
@@ -113,7 +113,7 @@ func TestShouldAddSuccessResponseFromAsyncStepResponseToChannel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			AddStepResponseToResumeChannel(tt.args.asyncStepResponseReq)
+			AddStepResponseToResumeChannel(&tt.args.asyncStepResponseReq)
 			time.Sleep(time.Second * 5)
 			assert.Equal(t, 0, len(serviceRequestChannel))
 			assert.Equal(t, 4, len(functionCalledStack))
@@ -195,7 +195,7 @@ func TestShouldAddFailureResponseFromAsyncStepResponseToChannel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			AddStepResponseToResumeChannel(tt.args.asyncStepResponseReq)
+			AddStepResponseToResumeChannel(&tt.args.asyncStepResponseReq)
 			time.Sleep(time.Second * 5)
 			assert.Equal(t, 0, len(serviceRequestChannel))
 			assert.Equal(t, 2, len(functionCalledStack))

--- a/services/async_resume_worker_test.go
+++ b/services/async_resume_worker_test.go
@@ -31,7 +31,8 @@ func prepareResponsePayload() map[string]interface{} {
 
 func TestShouldAddSuccessResponseFromAsyncStepResponseToChannel(t *testing.T) {
 	var functionCalledStack []string
-	findWorkflowByNameMock = func(workflowName string) (workflow models.Workflow, err error) {
+	findWorkflowByNameMock = func(workflowName string) (workflow *models.Workflow, err error) {
+		workflow = &models.Workflow{}
 		workflow.ID = "TEST_WF"
 		step := models.Step{
 			ID:        1,
@@ -50,9 +51,9 @@ func TestShouldAddSuccessResponseFromAsyncStepResponseToChannel(t *testing.T) {
 		functionCalledStack = append(functionCalledStack, "findWorkflowByName")
 		return workflow, err
 	}
-	saveStepStatusMock = func(stepStatus models.StepsStatus) (status models.StepsStatus, err error) {
+	saveStepStatusMock = func(stepStatus *models.StepsStatus) (status *models.StepsStatus, err error) {
 		functionCalledStack = append(functionCalledStack, "saveStepStatusMock")
-		return status, nil
+		return stepStatus, nil
 	}
 	type args struct {
 		asyncStepResponseReq models.AsyncStepResponse
@@ -75,8 +76,8 @@ func TestShouldAddSuccessResponseFromAsyncStepResponseToChannel(t *testing.T) {
 		},
 	}
 
-	findServiceRequestByIDMock = func(u uuid.UUID) (request models.ServiceRequest, err error) {
-		serviceRequest := models.ServiceRequest{
+	findServiceRequestByIDMock = func(u uuid.UUID) (request *models.ServiceRequest, err error) {
+		serviceRequest := &models.ServiceRequest{
 			ID:            serviceRequestID,
 			WorkflowName:  workflowName,
 			Status:        models.StatusNew,
@@ -88,8 +89,8 @@ func TestShouldAddSuccessResponseFromAsyncStepResponseToChannel(t *testing.T) {
 		return serviceRequest, err
 	}
 
-	findAllStepStatusByServiceRequestIDAndStepIDMock = func(serviceRequestId uuid.UUID, stepId int) (stepsStatus []models.StepsStatus, err error) {
-		var statuses = make([]models.StepsStatus, 1)
+	findAllStepStatusByServiceRequestIDAndStepIDMock = func(serviceRequestId uuid.UUID, stepId int) (stepsStatus []*models.StepsStatus, err error) {
+		var statuses = make([]*models.StepsStatus, 1)
 		stepStatus := models.StepsStatus{
 			ID:               "2",
 			ServiceRequestID: serviceRequestId,
@@ -105,7 +106,7 @@ func TestShouldAddSuccessResponseFromAsyncStepResponseToChannel(t *testing.T) {
 			},
 			StepID: 1,
 		}
-		statuses[0] = stepStatus
+		statuses[0] = &stepStatus
 		functionCalledStack = append(functionCalledStack, "findStepStatusByServiceRequestIdAndStepIdAndStatus")
 		return statuses, err
 	}
@@ -122,7 +123,8 @@ func TestShouldAddSuccessResponseFromAsyncStepResponseToChannel(t *testing.T) {
 
 func TestShouldAddFailureResponseFromAsyncStepResponseToChannel(t *testing.T) {
 	var functionCalledStack []string
-	findWorkflowByNameMock = func(workflowName string) (workflow models.Workflow, err error) {
+	findWorkflowByNameMock = func(workflowName string) (workflow *models.Workflow, err error) {
+		workflow = &models.Workflow{}
 		workflow.ID = "TEST_WF"
 		step := models.Step{
 			ID:        1,
@@ -141,9 +143,9 @@ func TestShouldAddFailureResponseFromAsyncStepResponseToChannel(t *testing.T) {
 		functionCalledStack = append(functionCalledStack, "findWorkflowByName")
 		return workflow, err
 	}
-	saveStepStatusMock = func(stepStatus models.StepsStatus) (status models.StepsStatus, err error) {
+	saveStepStatusMock = func(stepStatus *models.StepsStatus) (status *models.StepsStatus, err error) {
 		functionCalledStack = append(functionCalledStack, "saveStepStatusMock")
-		return status, nil
+		return stepStatus, nil
 	}
 	type args struct {
 		asyncStepResponseReq models.AsyncStepResponse
@@ -169,8 +171,8 @@ func TestShouldAddFailureResponseFromAsyncStepResponseToChannel(t *testing.T) {
 		},
 	}
 
-	findAllStepStatusByServiceRequestIDAndStepIDMock = func(serviceRequestId uuid.UUID, stepId int) (stepsStatus []models.StepsStatus, err error) {
-		var statuses = make([]models.StepsStatus, 1)
+	findAllStepStatusByServiceRequestIDAndStepIDMock = func(serviceRequestId uuid.UUID, stepId int) (stepsStatus []*models.StepsStatus, err error) {
+		var statuses = make([]*models.StepsStatus, 1)
 		stepStatus := models.StepsStatus{
 			ID:               "2",
 			ServiceRequestID: serviceRequestId,
@@ -186,7 +188,7 @@ func TestShouldAddFailureResponseFromAsyncStepResponseToChannel(t *testing.T) {
 			},
 			StepID: 1,
 		}
-		statuses[0] = stepStatus
+		statuses[0] = &stepStatus
 		functionCalledStack = append(functionCalledStack, "findStepStatusByServiceRequestIdAndStepIdAndStatus")
 		return statuses, err
 	}

--- a/services/request_context_service.go
+++ b/services/request_context_service.go
@@ -2,7 +2,7 @@ package services
 
 import "clamp-core/models"
 
-func CreateRequestContext(workflow models.Workflow, request models.ServiceRequest) (context models.RequestContext) {
+func CreateRequestContext(workflow *models.Workflow, request models.ServiceRequest) (context models.RequestContext) {
 	context = models.RequestContext{
 		ServiceRequestID: request.ID,
 		WorkflowName:     workflow.Name,
@@ -31,7 +31,7 @@ func EnhanceRequestContextWithExecutedSteps(context *models.RequestContext) {
 	}
 }
 
-func ComputeRequestToCurrentStepInContext(workflow models.Workflow, currentStepExecuting models.Step, requestContext *models.RequestContext, stepIndex int, stepRequestPayload map[string]interface{}) {
+func ComputeRequestToCurrentStepInContext(workflow *models.Workflow, currentStepExecuting models.Step, requestContext *models.RequestContext, stepIndex int, stepRequestPayload map[string]interface{}) {
 	if requestContext.GetStepRequestFromContext(currentStepExecuting.Name) == nil {
 		if stepIndex == 0 {
 			// for first step in execution

--- a/services/request_context_service.go
+++ b/services/request_context_service.go
@@ -2,13 +2,14 @@ package services
 
 import "clamp-core/models"
 
-func CreateRequestContext(workflow *models.Workflow, request models.ServiceRequest) (context models.RequestContext) {
+func CreateRequestContext(workflow *models.Workflow, request *models.ServiceRequest) (context models.RequestContext) {
 	context = models.RequestContext{
 		ServiceRequestID: request.ID,
 		WorkflowName:     workflow.Name,
 	}
 	context.StepsContext = make(map[string]*models.StepContext)
-	for _, step := range workflow.Steps {
+	for i := range workflow.Steps {
+		step := &workflow.Steps[i]
 		context.StepsContext[step.Name] = &models.StepContext{
 			Request:         nil,
 			Response:        nil,
@@ -31,7 +32,7 @@ func EnhanceRequestContextWithExecutedSteps(context *models.RequestContext) {
 	}
 }
 
-func ComputeRequestToCurrentStepInContext(workflow *models.Workflow, currentStepExecuting models.Step, requestContext *models.RequestContext, stepIndex int, stepRequestPayload map[string]interface{}) {
+func ComputeRequestToCurrentStepInContext(workflow *models.Workflow, currentStepExecuting *models.Step, requestContext *models.RequestContext, stepIndex int, stepRequestPayload map[string]interface{}) {
 	if requestContext.GetStepRequestFromContext(currentStepExecuting.Name) == nil {
 		if stepIndex == 0 {
 			// for first step in execution

--- a/services/request_context_service.go
+++ b/services/request_context_service.go
@@ -32,7 +32,8 @@ func EnhanceRequestContextWithExecutedSteps(context *models.RequestContext) {
 	}
 }
 
-func ComputeRequestToCurrentStepInContext(workflow *models.Workflow, currentStepExecuting *models.Step, requestContext *models.RequestContext, stepIndex int, stepRequestPayload map[string]interface{}) {
+func ComputeRequestToCurrentStepInContext(workflow *models.Workflow, currentStepExecuting *models.Step,
+	requestContext *models.RequestContext, stepIndex int, stepRequestPayload map[string]interface{}) {
 	if requestContext.GetStepRequestFromContext(currentStepExecuting.Name) == nil {
 		if stepIndex == 0 {
 			// for first step in execution

--- a/services/request_context_service_test.go
+++ b/services/request_context_service_test.go
@@ -43,7 +43,7 @@ func TestCreateRequestContext(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotContext := CreateRequestContext(tt.args.workflow, tt.args.request); !reflect.DeepEqual(gotContext, tt.wantContext) {
+			if gotContext := CreateRequestContext(&tt.args.workflow, tt.args.request); !reflect.DeepEqual(gotContext, tt.wantContext) {
 				t.Errorf("CreateRequestContext() = %v, want %v", gotContext, tt.wantContext)
 			}
 		})
@@ -51,7 +51,7 @@ func TestCreateRequestContext(t *testing.T) {
 }
 
 func TestShouldEnhanceRequestContext(t *testing.T) {
-	context := CreateRequestContext(models.Workflow{
+	context := CreateRequestContext(&models.Workflow{
 		Name: "TEST_WF",
 		Steps: []models.Step{{
 			Name: "step1",
@@ -61,11 +61,13 @@ func TestShouldEnhanceRequestContext(t *testing.T) {
 	}, models.ServiceRequest{
 		ID: uuid.New(),
 	})
-	findStepStatusByServiceRequestIDAndStatusMock = func(serviceRequestId uuid.UUID, status models.Status) ([]models.StepsStatus, error) {
-		stepsStatus := make([]models.StepsStatus, 2)
+	findStepStatusByServiceRequestIDAndStatusMock = func(serviceRequestId uuid.UUID, status models.Status) ([]*models.StepsStatus, error) {
+		stepsStatus := make([]*models.StepsStatus, 2)
+		stepsStatus[0] = &models.StepsStatus{}
 		stepsStatus[0].StepName = "step1"
 		stepsStatus[0].Payload.Request = map[string]interface{}{"k": "v"}
 		stepsStatus[0].Payload.Response = map[string]interface{}{"k": "v"}
+		stepsStatus[1] = &models.StepsStatus{}
 		stepsStatus[1].StepName = "step2"
 		stepsStatus[1].Payload.Request = map[string]interface{}{"k": "v"}
 		stepsStatus[1].Payload.Response = map[string]interface{}{"k": "v"}
@@ -97,7 +99,7 @@ func TestComputeRequestToCurrentStepInContext(t *testing.T) {
 			Name: "step3",
 		}},
 	}
-	context := CreateRequestContext(workflow, models.ServiceRequest{
+	context := CreateRequestContext(&workflow, models.ServiceRequest{
 		ID: uuid.New(),
 	})
 
@@ -151,7 +153,7 @@ func TestComputeRequestToCurrentStepInContext(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ComputeRequestToCurrentStepInContext(tt.args.workflow, tt.args.currentStepExecuting, tt.args.requestContext, tt.args.stepIndex, tt.args.stepRequestPayload)
+			ComputeRequestToCurrentStepInContext(&tt.args.workflow, tt.args.currentStepExecuting, tt.args.requestContext, tt.args.stepIndex, tt.args.stepRequestPayload)
 			tt.args.requestContext.SetStepResponseToContext(tt.args.currentStepExecuting.Name, map[string]interface{}{"response": "value"})
 			assert.NotNil(t, tt.args.requestContext.GetStepRequestFromContext(tt.args.currentStepExecuting.Name))
 		})

--- a/services/request_context_service_test.go
+++ b/services/request_context_service_test.go
@@ -43,7 +43,7 @@ func TestCreateRequestContext(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotContext := CreateRequestContext(&tt.args.workflow, tt.args.request); !reflect.DeepEqual(gotContext, tt.wantContext) {
+			if gotContext := CreateRequestContext(&tt.args.workflow, &tt.args.request); !reflect.DeepEqual(gotContext, tt.wantContext) {
 				t.Errorf("CreateRequestContext() = %v, want %v", gotContext, tt.wantContext)
 			}
 		})
@@ -58,7 +58,7 @@ func TestShouldEnhanceRequestContext(t *testing.T) {
 		}, {
 			Name: "step2",
 		}},
-	}, models.ServiceRequest{
+	}, &models.ServiceRequest{
 		ID: uuid.New(),
 	})
 	findStepStatusByServiceRequestIDAndStatusMock = func(serviceRequestId uuid.UUID, status models.Status) ([]*models.StepsStatus, error) {
@@ -99,7 +99,7 @@ func TestComputeRequestToCurrentStepInContext(t *testing.T) {
 			Name: "step3",
 		}},
 	}
-	context := CreateRequestContext(&workflow, models.ServiceRequest{
+	context := CreateRequestContext(&workflow, &models.ServiceRequest{
 		ID: uuid.New(),
 	})
 
@@ -153,7 +153,7 @@ func TestComputeRequestToCurrentStepInContext(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ComputeRequestToCurrentStepInContext(&tt.args.workflow, tt.args.currentStepExecuting, tt.args.requestContext, tt.args.stepIndex, tt.args.stepRequestPayload)
+			ComputeRequestToCurrentStepInContext(&tt.args.workflow, &tt.args.currentStepExecuting, tt.args.requestContext, tt.args.stepIndex, tt.args.stepRequestPayload)
 			tt.args.requestContext.SetStepResponseToContext(tt.args.currentStepExecuting.Name, map[string]interface{}{"response": "value"})
 			assert.NotNil(t, tt.args.requestContext.GetStepRequestFromContext(tt.args.currentStepExecuting.Name))
 		})

--- a/services/service_request_service.go
+++ b/services/service_request_service.go
@@ -19,7 +19,7 @@ func FindServiceRequestByID(serviceRequestID uuid.UUID) (*models.ServiceRequest,
 }
 
 // SaveServiceRequest is used to save the created service requests to DB
-func SaveServiceRequest(serviceReq models.ServiceRequest) (*models.ServiceRequest, error) {
+func SaveServiceRequest(serviceReq *models.ServiceRequest) (*models.ServiceRequest, error) {
 	log.Debugf("Saving service request: %v", serviceReq)
 	serviceRequest, err := repository.GetDB().SaveServiceRequest(serviceReq)
 	if err != nil {

--- a/services/service_request_service.go
+++ b/services/service_request_service.go
@@ -9,7 +9,7 @@ import (
 )
 
 // FindServiceRequestByID is used to fetch service requests by their ID values
-func FindServiceRequestByID(serviceRequestID uuid.UUID) (models.ServiceRequest, error) {
+func FindServiceRequestByID(serviceRequestID uuid.UUID) (*models.ServiceRequest, error) {
 	log.Debugf("Find service Request request by id: %s", serviceRequestID)
 	serviceRequest, err := repository.GetDB().FindServiceRequestByID(serviceRequestID)
 	if err != nil {
@@ -19,7 +19,7 @@ func FindServiceRequestByID(serviceRequestID uuid.UUID) (models.ServiceRequest, 
 }
 
 // SaveServiceRequest is used to save the created service requests to DB
-func SaveServiceRequest(serviceReq models.ServiceRequest) (models.ServiceRequest, error) {
+func SaveServiceRequest(serviceReq models.ServiceRequest) (*models.ServiceRequest, error) {
 	log.Debugf("Saving service request: %v", serviceReq)
 	serviceRequest, err := repository.GetDB().SaveServiceRequest(serviceReq)
 	if err != nil {
@@ -29,7 +29,7 @@ func SaveServiceRequest(serviceReq models.ServiceRequest) (models.ServiceRequest
 }
 
 // FindServiceRequestByWorkflowName fetches all ServiceRequests that are associated to a workflow type
-func FindServiceRequestByWorkflowName(workflowName string, pageNumber int, pageSize int) ([]models.ServiceRequest, error) {
+func FindServiceRequestByWorkflowName(workflowName string, pageNumber int, pageSize int) ([]*models.ServiceRequest, error) {
 	log.Debugf("Getting service request by workflow name: %s", workflowName)
 	serviceRequests, err := repository.GetDB().FindServiceRequestsByWorkflowName(workflowName, pageNumber, pageSize)
 	if err != nil {

--- a/services/service_request_service_test.go
+++ b/services/service_request_service_test.go
@@ -17,18 +17,18 @@ func TestSaveServiceRequest(t *testing.T) {
 		Status:       models.StatusNew,
 	}
 
-	saveServiceRequestMock = func(serReq models.ServiceRequest) (request models.ServiceRequest, err error) {
+	saveServiceRequestMock = func(serReq *models.ServiceRequest) (request *models.ServiceRequest, err error) {
 		return serReq, nil
 	}
-	request, err := SaveServiceRequest(serviceReq)
+	request, err := SaveServiceRequest(&serviceReq)
 	assert.NotNil(t, request)
 	assert.Nil(t, err)
 
-	saveServiceRequestMock = func(serReq models.ServiceRequest) (request models.ServiceRequest, err error) {
+	saveServiceRequestMock = func(serReq *models.ServiceRequest) (request *models.ServiceRequest, err error) {
 		return serReq, errors.New("insertion failed")
 	}
 	serviceReq.WorkflowName = ""
-	_, err = SaveServiceRequest(serviceReq)
+	_, err = SaveServiceRequest(&serviceReq)
 	assert.NotNil(t, err)
 	assert.Equal(t, "insertion failed", err.Error())
 }
@@ -40,12 +40,12 @@ func TestShouldFailToSaveServiceRequestAndThrowError(t *testing.T) {
 		Status:       models.StatusNew,
 	}
 
-	saveServiceRequestMock = func(serReq models.ServiceRequest) (request models.ServiceRequest, err error) {
-		return models.ServiceRequest{}, errors.New("insertion failed")
+	saveServiceRequestMock = func(serReq *models.ServiceRequest) (request *models.ServiceRequest, err error) {
+		return &models.ServiceRequest{}, errors.New("insertion failed")
 	}
 	serviceReq.WorkflowName = ""
-	request, err := SaveServiceRequest(serviceReq)
-	assert.Equal(t, models.ServiceRequest{}, request)
+	request, err := SaveServiceRequest(&serviceReq)
+	assert.Equal(t, models.ServiceRequest{}, *request)
 	assert.NotNil(t, err)
 	assert.Equal(t, "insertion failed", err.Error())
 }
@@ -55,7 +55,8 @@ func TestFindByID(t *testing.T) {
 	serviceReq := models.ServiceRequest{
 		ID: uuid.UUID{},
 	}
-	findServiceRequestByIDMock = func(id uuid.UUID) (request models.ServiceRequest, err error) {
+	findServiceRequestByIDMock = func(id uuid.UUID) (request *models.ServiceRequest, err error) {
+		request = &models.ServiceRequest{}
 		request.WorkflowName = "TEST_WF"
 		request.Status = models.StatusCompleted
 		return request, nil
@@ -65,7 +66,8 @@ func TestFindByID(t *testing.T) {
 	assert.Equal(t, "TEST_WF", resp.WorkflowName)
 	assert.Equal(t, models.StatusCompleted, resp.Status)
 
-	findServiceRequestByIDMock = func(id uuid.UUID) (request models.ServiceRequest, err error) {
+	findServiceRequestByIDMock = func(id uuid.UUID) (request *models.ServiceRequest, err error) {
+		request = &models.ServiceRequest{}
 		return request, errors.New("select query failed")
 	}
 	_, err = FindServiceRequestByID(serviceReq.ID)
@@ -77,8 +79,8 @@ func TestFindServiceRequestsByWorkflowName(t *testing.T) {
 	serviceReq := models.ServiceRequest{
 		ID: uuid.UUID{},
 	}
-	findServiceRequestsByWorkflowName = func(workflowName string, pageNumber int, pageSize int) ([]models.ServiceRequest, error) {
-		return []models.ServiceRequest{serviceReq}, nil
+	findServiceRequestsByWorkflowName = func(workflowName string, pageNumber int, pageSize int) ([]*models.ServiceRequest, error) {
+		return []*models.ServiceRequest{&serviceReq}, nil
 	}
 	resp, err := findServiceRequestsByWorkflowName("test", 1, 1)
 	assert.Nil(t, err)

--- a/services/service_request_worker.go
+++ b/services/service_request_worker.go
@@ -54,7 +54,8 @@ func worker(workerID int, serviceReqChan <-chan models.ServiceRequest) {
 	prefix = fmt.Sprintf("%15s", prefix)
 	log.Infof("%s : Started listening to service request channel", prefix)
 	for serviceReq := range serviceReqChan {
-		executeWorkflow(&serviceReq, prefix)
+		serviceReqCopy := serviceReq
+		executeWorkflow(&serviceReqCopy, prefix)
 	}
 }
 

--- a/services/service_request_worker.go
+++ b/services/service_request_worker.go
@@ -87,7 +87,7 @@ func catchErrors(prefix string, requestID uuid.UUID) {
 	}
 }
 
-func executeWorkflowSteps(workflow models.Workflow, prefix string, serviceRequest models.ServiceRequest) models.Status {
+func executeWorkflowSteps(workflow *models.Workflow, prefix string, serviceRequest models.ServiceRequest) models.Status {
 	stepRequestPayload := serviceRequest.Payload
 	lastStepExecuted := serviceRequest.CurrentStepID
 	executeStepsFromIndex := 0
@@ -127,7 +127,7 @@ func ExecuteWorkflowStep(step models.Step, requestContext models.RequestContext,
 	requestContext.SetStepRequestToContext(step.Name, stepRequest)
 
 	stepStartTime := time.Now()
-	stepStatus := models.StepsStatus{
+	stepStatus := &models.StepsStatus{
 		ServiceRequestID: serviceRequestID,
 		WorkflowName:     workflowName,
 		StepName:         step.Name,
@@ -178,31 +178,31 @@ func ExecuteWorkflowStep(step models.Step, requestContext models.RequestContext,
 	return models.EmptyErrorResponse()
 }
 
-func recordStepCompletionStatus(stepStatus models.StepsStatus, stepStartTime time.Time) {
+func recordStepCompletionStatus(stepStatus *models.StepsStatus, stepStartTime time.Time) {
 	stepStatus.Status = models.StatusCompleted
 	stepStatus.TotalTimeInMs = time.Since(stepStartTime).Nanoseconds() / utils.MilliSecondsDivisor
 	SaveStepStatus(stepStatus)
 }
 
-func recordStepSkippedStatus(stepStatus models.StepsStatus, stepStartTime time.Time) {
+func recordStepSkippedStatus(stepStatus *models.StepsStatus, stepStartTime time.Time) {
 	stepStatus.Status = models.StatusSkipped
 	stepStatus.TotalTimeInMs = time.Since(stepStartTime).Nanoseconds() / utils.MilliSecondsDivisor
 	SaveStepStatus(stepStatus)
 }
 
-func recordStepPausedStatus(stepStatus models.StepsStatus, stepStartTime time.Time) {
+func recordStepPausedStatus(stepStatus *models.StepsStatus, stepStartTime time.Time) {
 	stepStatus.Status = models.StatusPaused
 	stepStatus.TotalTimeInMs = time.Since(stepStartTime).Nanoseconds() / utils.MilliSecondsDivisor
 	SaveStepStatus(stepStatus)
 }
 
-func recordStepStartedStatus(stepStatus models.StepsStatus, stepStartTime time.Time) {
+func recordStepStartedStatus(stepStatus *models.StepsStatus, stepStartTime time.Time) {
 	stepStatus.Status = models.StatusStarted
 	stepStatus.TotalTimeInMs = time.Since(stepStartTime).Nanoseconds() / utils.MilliSecondsDivisor
 	SaveStepStatus(stepStatus)
 }
 
-func recordStepFailedStatus(stepStatus models.StepsStatus, clampErrorResponse models.ClampErrorResponse, stepStartTime time.Time) {
+func recordStepFailedStatus(stepStatus *models.StepsStatus, clampErrorResponse models.ClampErrorResponse, stepStartTime time.Time) {
 	stepStatus.Status = models.StatusFailed
 	marshal, err := json.Marshal(clampErrorResponse)
 	if err != nil {
@@ -231,7 +231,7 @@ func getServiceRequestChannel() chan models.ServiceRequest {
 	return serviceRequestChannel
 }
 
-func AddServiceRequestToChannel(serviceReq models.ServiceRequest) {
+func AddServiceRequestToChannel(serviceReq *models.ServiceRequest) {
 	channel := getServiceRequestChannel()
-	channel <- serviceReq
+	channel <- *serviceReq
 }

--- a/services/service_request_worker_test.go
+++ b/services/service_request_worker_test.go
@@ -16,7 +16,8 @@ const workflowName string = "testWF"
 
 func TestAddServiceRequestToChannel(t *testing.T) {
 	var functionCalledStack []string
-	findWorkflowByNameMock = func(workflowName string) (workflow models.Workflow, err error) {
+	findWorkflowByNameMock = func(workflowName string) (workflow *models.Workflow, err error) {
+		workflow = &models.Workflow{}
 		workflow.ID = "TEST_WF"
 		step := models.Step{
 			Name:      "1",
@@ -34,8 +35,9 @@ func TestAddServiceRequestToChannel(t *testing.T) {
 		functionCalledStack = append(functionCalledStack, "findWorkflowByName")
 		return workflow, err
 	}
-	saveStepStatusMock = func(stepStatus models.StepsStatus) (status models.StepsStatus, err error) {
+	saveStepStatusMock = func(stepStatus *models.StepsStatus) (status *models.StepsStatus, err error) {
 		functionCalledStack = append(functionCalledStack, "saveStepStatusMock")
+		status = &models.StepsStatus{}
 		return status, nil
 	}
 	type args struct {
@@ -59,7 +61,7 @@ func TestAddServiceRequestToChannel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			AddServiceRequestToChannel(tt.args.serviceReq)
+			AddServiceRequestToChannel(&tt.args.serviceReq)
 			time.Sleep(time.Second * 5)
 			assert.Equal(t, 0, len(serviceRequestChannel))
 			assert.Equal(t, 3, len(functionCalledStack))
@@ -69,7 +71,8 @@ func TestAddServiceRequestToChannel(t *testing.T) {
 
 func TestShouldAddServiceRequestToChannelWithTransformationEnabledForOneStepInTheWorkflow(t *testing.T) {
 	var functionCalledStack []string
-	findWorkflowByNameMock = func(workflowName string) (workflow models.Workflow, err error) {
+	findWorkflowByNameMock = func(workflowName string) (workflow *models.Workflow, err error) {
+		workflow = &models.Workflow{}
 		workflow.ID = "TEST_WF"
 		step := models.Step{
 			Name:      "1",
@@ -90,8 +93,9 @@ func TestShouldAddServiceRequestToChannelWithTransformationEnabledForOneStepInTh
 		functionCalledStack = append(functionCalledStack, "findWorkflowByName")
 		return workflow, err
 	}
-	saveStepStatusMock = func(stepStatus models.StepsStatus) (status models.StepsStatus, err error) {
+	saveStepStatusMock = func(stepStatus *models.StepsStatus) (status *models.StepsStatus, err error) {
 		functionCalledStack = append(functionCalledStack, "saveStepStatusMock")
+		status = &models.StepsStatus{}
 		return status, nil
 	}
 	type args struct {
@@ -115,7 +119,7 @@ func TestShouldAddServiceRequestToChannelWithTransformationEnabledForOneStepInTh
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			AddServiceRequestToChannel(tt.args.serviceReq)
+			AddServiceRequestToChannel(&tt.args.serviceReq)
 			time.Sleep(time.Second * 5)
 			assert.Equal(t, 0, len(serviceRequestChannel))
 			assert.Equal(t, 3, len(functionCalledStack))
@@ -125,7 +129,8 @@ func TestShouldAddServiceRequestToChannelWithTransformationEnabledForOneStepInTh
 
 func TestShouldSkipStepIfConditionDoesNotMatch(t *testing.T) {
 	var functionCalledStack []string
-	findWorkflowByNameMock = func(workflowName string) (workflow models.Workflow, err error) {
+	findWorkflowByNameMock = func(workflowName string) (workflow *models.Workflow, err error) {
+		workflow = &models.Workflow{}
 		workflow.ID = "TEST_WF"
 		step := models.Step{
 			Name:      "skipStep",
@@ -144,8 +149,9 @@ func TestShouldSkipStepIfConditionDoesNotMatch(t *testing.T) {
 		functionCalledStack = append(functionCalledStack, "findWorkflowByName")
 		return workflow, err
 	}
-	saveStepStatusMock = func(stepStatus models.StepsStatus) (status models.StepsStatus, err error) {
+	saveStepStatusMock = func(stepStatus *models.StepsStatus) (status *models.StepsStatus, err error) {
 		functionCalledStack = append(functionCalledStack, "saveStepStatusMock")
+		status = &models.StepsStatus{}
 		return status, nil
 	}
 	type args struct {
@@ -170,7 +176,7 @@ func TestShouldSkipStepIfConditionDoesNotMatch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			AddServiceRequestToChannel(tt.args.serviceReq)
+			AddServiceRequestToChannel(&tt.args.serviceReq)
 			time.Sleep(time.Second * 5)
 			assert.Equal(t, 0, len(serviceRequestChannel))
 			assert.Equal(t, 3, len(functionCalledStack))
@@ -180,7 +186,8 @@ func TestShouldSkipStepIfConditionDoesNotMatch(t *testing.T) {
 
 func TestShouldResumeTheWorkflowExecutionFromNextStep(t *testing.T) {
 	var functionCalledStack []string
-	findWorkflowByNameMock = func(workflowName string) (workflow models.Workflow, err error) {
+	findWorkflowByNameMock = func(workflowName string) (workflow *models.Workflow, err error) {
+		workflow = &models.Workflow{}
 		workflow.ID = "TEST_WF"
 		step := models.Step{
 			Name:      "firstStep",
@@ -212,13 +219,15 @@ func TestShouldResumeTheWorkflowExecutionFromNextStep(t *testing.T) {
 		functionCalledStack = append(functionCalledStack, "findWorkflowByName")
 		return workflow, err
 	}
-	saveStepStatusMock = func(stepStatus models.StepsStatus) (status models.StepsStatus, err error) {
+	saveStepStatusMock = func(stepStatus *models.StepsStatus) (status *models.StepsStatus, err error) {
 		functionCalledStack = append(functionCalledStack, "saveStepStatusMock")
+		status = &models.StepsStatus{}
 		return status, nil
 	}
-	findStepStatusByServiceRequestIDAndStatusMock = func(serviceRequestId uuid.UUID, status models.Status) ([]models.StepsStatus, error) {
+	findStepStatusByServiceRequestIDAndStatusMock = func(serviceRequestId uuid.UUID, status models.Status) ([]*models.StepsStatus, error) {
 		functionCalledStack = append(functionCalledStack, "findStepStatusByServiceRequestIdAndStatus")
-		stepsStatus := make([]models.StepsStatus, 1)
+		stepsStatus := make([]*models.StepsStatus, 1)
+		stepsStatus[0] = &models.StepsStatus{}
 		stepsStatus[0].StepName = "firstStep"
 		stepsStatus[0].Payload.Request = map[string]interface{}{"k": "v"}
 		stepsStatus[0].Payload.Response = map[string]interface{}{"k": "v"}
@@ -247,7 +256,7 @@ func TestShouldResumeTheWorkflowExecutionFromNextStep(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			AddServiceRequestToChannel(tt.args.serviceReq)
+			AddServiceRequestToChannel(&tt.args.serviceReq)
 			time.Sleep(time.Second * 5)
 			assert.Equal(t, 0, len(serviceRequestChannel))
 			assert.Equal(t, 4, len(functionCalledStack))

--- a/services/step_status_service.go
+++ b/services/step_status_service.go
@@ -74,7 +74,8 @@ func FindAllStepStatusByServiceRequestIDAndStepID(serviceRequestID uuid.UUID, st
 	return stepsStatuses, err
 }
 
-func PrepareStepStatusResponse(srvReqID uuid.UUID, workflow *models.Workflow, stepsStatusArr []*models.StepsStatus) *models.ServiceRequestStatusResponse {
+func PrepareStepStatusResponse(srvReqID uuid.UUID,
+	workflow *models.Workflow, stepsStatusArr []*models.StepsStatus) *models.ServiceRequestStatusResponse {
 	var srvReqStatusRes models.ServiceRequestStatusResponse
 	srvReqStatusRes.ServiceRequestID = srvReqID
 	srvReqStatusRes.WorkflowName = workflow.Name

--- a/services/step_status_service.go
+++ b/services/step_status_service.go
@@ -27,7 +27,7 @@ var (
 	})
 )
 
-func SaveStepStatus(stepStatusReq models.StepsStatus) (*models.StepsStatus, error) {
+func SaveStepStatus(stepStatusReq *models.StepsStatus) (*models.StepsStatus, error) {
 	log.Debugf("Saving step status : %v", stepStatusReq)
 	stepStatusReq, err := repository.GetDB().SaveStepStatus(stepStatusReq)
 	if err != nil {
@@ -49,7 +49,7 @@ func FindStepStatusByServiceRequestID(serviceRequestID uuid.UUID) ([]*models.Ste
 	stepsStatuses, err := repository.GetDB().FindStepStatusByServiceRequestID(serviceRequestID)
 	if err != nil {
 		log.Errorf("No record found with given service request id %s", serviceRequestID)
-		return []models.StepsStatus{}, err
+		return []*models.StepsStatus{}, err
 	}
 	return stepsStatuses, err
 }
@@ -59,7 +59,7 @@ func FindStepStatusByServiceRequestIDAndStatus(serviceRequestID uuid.UUID, statu
 	stepsStatuses, err := repository.GetDB().FindStepStatusByServiceRequestIDAndStatus(serviceRequestID, status)
 	if err != nil {
 		log.Errorf("No record found with given service request id %s", serviceRequestID)
-		return []models.StepsStatus{}, err
+		return []*models.StepsStatus{}, err
 	}
 	return stepsStatuses, err
 }

--- a/services/step_status_service.go
+++ b/services/step_status_service.go
@@ -27,12 +27,13 @@ var (
 	})
 )
 
-func SaveStepStatus(stepStatusReq models.StepsStatus) (models.StepsStatus, error) {
+func SaveStepStatus(stepStatusReq models.StepsStatus) (*models.StepsStatus, error) {
 	log.Debugf("Saving step status : %v", stepStatusReq)
 	stepStatusReq, err := repository.GetDB().SaveStepStatus(stepStatusReq)
 	if err != nil {
 		log.Errorf("Failed saving step status : %v, %s", stepStatusReq, err.Error())
 	}
+
 	serviceRequestStepNameTimeExecutorCounter.WithLabelValues(stepStatusReq.ServiceRequestID.String(),
 		stepStatusReq.StepName, string(stepStatusReq.Status)).Add(float64(stepStatusReq.TotalTimeInMs))
 
@@ -43,7 +44,7 @@ func SaveStepStatus(stepStatusReq models.StepsStatus) (models.StepsStatus, error
 	return stepStatusReq, err
 }
 
-func FindStepStatusByServiceRequestID(serviceRequestID uuid.UUID) ([]models.StepsStatus, error) {
+func FindStepStatusByServiceRequestID(serviceRequestID uuid.UUID) ([]*models.StepsStatus, error) {
 	log.Debugf("Find step statues by request id : %s ", serviceRequestID)
 	stepsStatuses, err := repository.GetDB().FindStepStatusByServiceRequestID(serviceRequestID)
 	if err != nil {
@@ -53,7 +54,7 @@ func FindStepStatusByServiceRequestID(serviceRequestID uuid.UUID) ([]models.Step
 	return stepsStatuses, err
 }
 
-func FindStepStatusByServiceRequestIDAndStatus(serviceRequestID uuid.UUID, status models.Status) ([]models.StepsStatus, error) {
+func FindStepStatusByServiceRequestIDAndStatus(serviceRequestID uuid.UUID, status models.Status) ([]*models.StepsStatus, error) {
 	log.Debugf("Find step statues by request id : %s ", serviceRequestID)
 	stepsStatuses, err := repository.GetDB().FindStepStatusByServiceRequestIDAndStatus(serviceRequestID, status)
 	if err != nil {
@@ -63,17 +64,17 @@ func FindStepStatusByServiceRequestIDAndStatus(serviceRequestID uuid.UUID, statu
 	return stepsStatuses, err
 }
 
-func FindAllStepStatusByServiceRequestIDAndStepID(serviceRequestID uuid.UUID, stepID int) ([]models.StepsStatus, error) {
+func FindAllStepStatusByServiceRequestIDAndStepID(serviceRequestID uuid.UUID, stepID int) ([]*models.StepsStatus, error) {
 	log.Debugf("Find all step statues by request id : %s and step id : %d", serviceRequestID, stepID)
 	stepsStatuses, err := repository.GetDB().FindAllStepStatusByServiceRequestIDAndStepID(serviceRequestID, stepID)
 	if err != nil {
 		log.Errorf("No record found with given service request id %s", serviceRequestID)
-		return []models.StepsStatus{}, err
+		return []*models.StepsStatus{}, err
 	}
 	return stepsStatuses, err
 }
 
-func PrepareStepStatusResponse(srvReqID uuid.UUID, workflow models.Workflow, stepsStatusArr []models.StepsStatus) models.ServiceRequestStatusResponse {
+func PrepareStepStatusResponse(srvReqID uuid.UUID, workflow *models.Workflow, stepsStatusArr []*models.StepsStatus) *models.ServiceRequestStatusResponse {
 	var srvReqStatusRes models.ServiceRequestStatusResponse
 	srvReqStatusRes.ServiceRequestID = srvReqID
 	srvReqStatusRes.WorkflowName = workflow.Name
@@ -116,7 +117,7 @@ func PrepareStepStatusResponse(srvReqID uuid.UUID, workflow models.Workflow, ste
 		srvReqStatusRes.TotalTimeInMs = timeTaken.Nanoseconds() / utils.MilliSecondsDivisor
 		srvReqStatusRes.Steps = stepsStatusRes
 	}
-	return srvReqStatusRes
+	return &srvReqStatusRes
 }
 
 func calculateTimeTaken(startTime time.Time, endTime time.Time) time.Duration {

--- a/services/step_status_service_test.go
+++ b/services/step_status_service_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func prepareStepsStatus() models.StepsStatus {
+func prepareStepsStatus() *models.StepsStatus {
 	stepsStatus := models.StepsStatus{
 		ID:               "1",
 		ServiceRequestID: uuid.New(),
@@ -21,12 +21,12 @@ func prepareStepsStatus() models.StepsStatus {
 		StepName:         "Testing",
 		TotalTimeInMs:    10,
 	}
-	return stepsStatus
+	return &stepsStatus
 }
 func TestSaveStepsStatus(t *testing.T) {
 
 	stepsStatusReq := prepareStepsStatus()
-	saveStepStatusMock = func(stepStatus models.StepsStatus) (status models.StepsStatus, err error) {
+	saveStepStatusMock = func(stepStatus *models.StepsStatus) (status *models.StepsStatus, err error) {
 		return stepStatus, nil
 	}
 	response, err := SaveStepStatus(stepsStatusReq)
@@ -37,7 +37,8 @@ func TestSaveStepsStatus(t *testing.T) {
 	assert.Equal(t, stepsStatusReq.TotalTimeInMs, response.TotalTimeInMs, fmt.Sprintf("Expected Total time in ms to be %d but was %d", stepsStatusReq.TotalTimeInMs, response.TotalTimeInMs))
 	assert.Equal(t, stepsStatusReq.Status, response.Status, fmt.Sprintf("Expected Step status to be %s but was %s", stepsStatusReq.Status, response.Status))
 
-	saveStepStatusMock = func(stepStatus models.StepsStatus) (status models.StepsStatus, err error) {
+	saveStepStatusMock = func(stepStatus *models.StepsStatus) (status *models.StepsStatus, err error) {
+		status = &models.StepsStatus{}
 		return status, errors.New("insertion failed")
 	}
 	response, err = SaveStepStatus(stepsStatusReq)
@@ -46,29 +47,33 @@ func TestSaveStepsStatus(t *testing.T) {
 
 func TestFindStepStatusByServiceRequestId(t *testing.T) {
 	stepsStatusReq := prepareStepsStatus()
-	findStepStatusByServiceRequestIDMock = func(serviceRequestId uuid.UUID) (statuses []models.StepsStatus, err error) {
+	findStepStatusByServiceRequestIDMock = func(serviceRequestId uuid.UUID) (statuses []*models.StepsStatus, err error) {
 		step1Time := time.Date(2020, time.April, 07, 16, 32, 00, 00, time.UTC)
 		step2Time := time.Date(2020, time.April, 07, 16, 32, 00, 20000000, time.UTC)
 
-		statuses = make([]models.StepsStatus, 4)
+		statuses = make([]*models.StepsStatus, 4)
+		statuses[0] = &models.StepsStatus{}
 		statuses[0].WorkflowName = stepsStatusReq.WorkflowName
 		statuses[0].ID = stepsStatusReq.ID
 		statuses[0].Status = models.StatusStarted
 		statuses[0].StepName = stepsStatusReq.StepName
 		statuses[0].TotalTimeInMs = stepsStatusReq.TotalTimeInMs
 		statuses[0].CreatedAt = step1Time
+		statuses[1] = &models.StepsStatus{}
 		statuses[1].WorkflowName = stepsStatusReq.WorkflowName
 		statuses[1].ID = stepsStatusReq.ID
 		statuses[1].Status = stepsStatusReq.Status
 		statuses[1].StepName = stepsStatusReq.StepName
 		statuses[1].TotalTimeInMs = stepsStatusReq.TotalTimeInMs
 		statuses[1].CreatedAt = step1Time
+		statuses[2] = &models.StepsStatus{}
 		statuses[2].WorkflowName = stepsStatusReq.WorkflowName
 		statuses[2].ID = "2"
 		statuses[2].Status = models.StatusStarted
 		statuses[2].StepName = "step2"
 		statuses[2].TotalTimeInMs = stepsStatusReq.TotalTimeInMs
 		statuses[2].CreatedAt = step2Time
+		statuses[3] = &models.StepsStatus{}
 		statuses[3].WorkflowName = stepsStatusReq.WorkflowName
 		statuses[3].ID = "2"
 		statuses[3].Status = stepsStatusReq.Status
@@ -87,7 +92,7 @@ func TestFindStepStatusByServiceRequestId(t *testing.T) {
 		UpdatedAt:   time.Time{},
 		Steps:       make([]models.Step, 2),
 	}
-	resp := PrepareStepStatusResponse(stepsStatusReq.ServiceRequestID, workflow, stepsStatus)
+	resp := PrepareStepStatusResponse(stepsStatusReq.ServiceRequestID, &workflow, stepsStatus)
 	assert.Nil(t, err)
 	assert.Equal(t, stepsStatusReq.WorkflowName, resp.WorkflowName)
 	assert.Equal(t, models.StatusCompleted, resp.Status)
@@ -102,7 +107,7 @@ func TestFindStepStatusByServiceRequestId(t *testing.T) {
 	assert.Equal(t, "step2", resp.Steps[2].Name)
 	assert.Equal(t, stepsStatusReq.TotalTimeInMs, resp.Steps[2].TimeTaken)
 
-	findStepStatusByServiceRequestIDMock = func(serviceRequestId uuid.UUID) (statuses []models.StepsStatus, err error) {
+	findStepStatusByServiceRequestIDMock = func(serviceRequestId uuid.UUID) (statuses []*models.StepsStatus, err error) {
 		return statuses, errors.New("select query failed")
 	}
 	_, err = FindStepStatusByServiceRequestID(stepsStatusReq.ServiceRequestID)
@@ -110,17 +115,20 @@ func TestFindStepStatusByServiceRequestId(t *testing.T) {
 }
 
 func TestShouldReturnStatusCompletedForAllStepsCompleted(t *testing.T) {
-	findStepStatusByServiceRequestIDMock = func(serviceRequestId uuid.UUID) (statuses []models.StepsStatus, err error) {
+	findStepStatusByServiceRequestIDMock = func(serviceRequestId uuid.UUID) (statuses []*models.StepsStatus, err error) {
 		step1Time := time.Date(2020, time.April, 07, 16, 32, 00, 00, time.UTC)
 
-		statuses = make([]models.StepsStatus, 4)
+		statuses = make([]*models.StepsStatus, 4)
 		workflowName := "testWF"
+		statuses[0] = &models.StepsStatus{}
 		statuses[0].WorkflowName = workflowName
 		statuses[0].ID = "1"
 		statuses[0].Status = models.StatusStarted
 		statuses[0].StepName = "step1"
 		statuses[0].TotalTimeInMs = 10
 		statuses[0].CreatedAt = step1Time
+
+		statuses[1] = &models.StepsStatus{}
 		statuses[1].WorkflowName = workflowName
 		statuses[1].ID = "2"
 		statuses[1].Status = models.StatusCompleted
@@ -128,12 +136,15 @@ func TestShouldReturnStatusCompletedForAllStepsCompleted(t *testing.T) {
 		statuses[1].TotalTimeInMs = 20
 		statuses[1].CreatedAt = step1Time.Add(time.Second * 10)
 
+		statuses[2] = &models.StepsStatus{}
 		statuses[2].WorkflowName = workflowName
 		statuses[2].ID = "3"
 		statuses[2].Status = models.StatusStarted
 		statuses[2].StepName = "step2"
 		statuses[2].TotalTimeInMs = 10
 		statuses[2].CreatedAt = step1Time.Add(time.Second * 20)
+
+		statuses[3] = &models.StepsStatus{}
 		statuses[3].WorkflowName = workflowName
 		statuses[3].ID = "4"
 		statuses[3].Status = models.StatusCompleted
@@ -153,22 +164,25 @@ func TestShouldReturnStatusCompletedForAllStepsCompleted(t *testing.T) {
 		UpdatedAt:   time.Time{},
 		Steps:       make([]models.Step, 2),
 	}
-	resp := PrepareStepStatusResponse(serviceReqID, workflow, stepsStatus)
+	resp := PrepareStepStatusResponse(serviceReqID, &workflow, stepsStatus)
 	assert.Nil(t, err)
 	assert.Equal(t, models.StatusCompleted, resp.Status)
 }
 
 func TestShouldReturnStatusFailed(t *testing.T) {
-	findStepStatusByServiceRequestIDMock = func(serviceRequestId uuid.UUID) (statuses []models.StepsStatus, err error) {
+	findStepStatusByServiceRequestIDMock = func(serviceRequestId uuid.UUID) (statuses []*models.StepsStatus, err error) {
 		step1Time := time.Date(2020, time.April, 07, 16, 32, 00, 00, time.UTC)
 
-		statuses = make([]models.StepsStatus, 4)
+		statuses = make([]*models.StepsStatus, 4)
+		statuses[0] = &models.StepsStatus{}
 		statuses[0].WorkflowName = "testWF"
 		statuses[0].ID = "1"
 		statuses[0].Status = models.StatusStarted
 		statuses[0].StepName = "step1"
 		statuses[0].TotalTimeInMs = 10
 		statuses[0].CreatedAt = step1Time
+
+		statuses[1] = &models.StepsStatus{}
 		statuses[1].WorkflowName = "testWF"
 		statuses[1].ID = "2"
 		statuses[1].Status = models.StatusCompleted
@@ -176,12 +190,15 @@ func TestShouldReturnStatusFailed(t *testing.T) {
 		statuses[1].TotalTimeInMs = 20
 		statuses[1].CreatedAt = step1Time.Add(time.Second * 10)
 
+		statuses[2] = &models.StepsStatus{}
 		statuses[2].WorkflowName = "testWF"
 		statuses[2].ID = "3"
 		statuses[2].Status = models.StatusStarted
 		statuses[2].StepName = "step2"
 		statuses[2].TotalTimeInMs = 10
 		statuses[2].CreatedAt = step1Time.Add(time.Second * 20)
+
+		statuses[3] = &models.StepsStatus{}
 		statuses[3].WorkflowName = "testWF"
 		statuses[3].ID = "4"
 		statuses[3].Status = models.StatusFailed
@@ -200,22 +217,25 @@ func TestShouldReturnStatusFailed(t *testing.T) {
 		UpdatedAt:   time.Time{},
 		Steps:       make([]models.Step, 2),
 	}
-	resp := PrepareStepStatusResponse(serviceReqID, workflow, stepsStatus)
+	resp := PrepareStepStatusResponse(serviceReqID, &workflow, stepsStatus)
 	assert.Nil(t, err)
 	assert.Equal(t, models.StatusFailed, resp.Status)
 }
 
 func TestShouldReturnStatusInprogress(t *testing.T) {
-	findStepStatusByServiceRequestIDMock = func(serviceRequestId uuid.UUID) (statuses []models.StepsStatus, err error) {
+	findStepStatusByServiceRequestIDMock = func(serviceRequestId uuid.UUID) (statuses []*models.StepsStatus, err error) {
 		step1Time := time.Date(2020, time.April, 07, 16, 32, 00, 00, time.UTC)
 
-		statuses = make([]models.StepsStatus, 4)
+		statuses = make([]*models.StepsStatus, 3)
+		statuses[0] = &models.StepsStatus{}
 		statuses[0].WorkflowName = "testWF"
 		statuses[0].ID = "1"
 		statuses[0].Status = models.StatusStarted
 		statuses[0].StepName = "step1"
 		statuses[0].TotalTimeInMs = 10
 		statuses[0].CreatedAt = step1Time
+
+		statuses[1] = &models.StepsStatus{}
 		statuses[1].WorkflowName = "testWF"
 		statuses[1].ID = "2"
 		statuses[1].Status = models.StatusCompleted
@@ -223,6 +243,7 @@ func TestShouldReturnStatusInprogress(t *testing.T) {
 		statuses[1].TotalTimeInMs = 20
 		statuses[1].CreatedAt = step1Time.Add(time.Second * 10)
 
+		statuses[2] = &models.StepsStatus{}
 		statuses[2].WorkflowName = "testWF"
 		statuses[2].ID = "3"
 		statuses[2].Status = models.StatusStarted
@@ -242,17 +263,18 @@ func TestShouldReturnStatusInprogress(t *testing.T) {
 		UpdatedAt:   time.Time{},
 		Steps:       make([]models.Step, 2),
 	}
-	resp := PrepareStepStatusResponse(serviceReqID, workflow, stepsStatus)
+	resp := PrepareStepStatusResponse(serviceReqID, &workflow, stepsStatus)
 	assert.Nil(t, err)
 	assert.Equal(t, models.StatusInprogress, resp.Status)
 }
 
 func TestFindStepStatusByServiceRequestIdAndStatusOrderByCreatedAtDesc(t *testing.T) {
 	stepsStatusReq := prepareStepsStatus()
-	findStepStatusByServiceRequestIDAndStatusMock = func(serviceRequestId uuid.UUID, status models.Status) (statuses []models.StepsStatus, err error) {
+	findStepStatusByServiceRequestIDAndStatusMock = func(serviceRequestId uuid.UUID, status models.Status) (statuses []*models.StepsStatus, err error) {
 		step1Time := time.Date(2020, time.April, 07, 16, 32, 00, 00, time.UTC)
 
-		statuses = make([]models.StepsStatus, 1)
+		statuses = make([]*models.StepsStatus, 1)
+		statuses[0] = &models.StepsStatus{}
 		statuses[0].WorkflowName = "testWF"
 		statuses[0].ID = "1"
 		statuses[0].Status = models.StatusStarted
@@ -273,7 +295,7 @@ func TestFindStepStatusByServiceRequestIdAndStatusOrderByCreatedAtDesc(t *testin
 	assert.Equal(t, "step1", stepsStatus.StepName)
 	assert.Equal(t, stepsStatusReq.TotalTimeInMs, stepsStatus.TotalTimeInMs)
 
-	findStepStatusByServiceRequestIDAndStatusMock = func(serviceRequestId uuid.UUID, status models.Status) (statuses []models.StepsStatus, err error) {
+	findStepStatusByServiceRequestIDAndStatusMock = func(serviceRequestId uuid.UUID, status models.Status) (statuses []*models.StepsStatus, err error) {
 		return statuses, errors.New("select query failed")
 	}
 	_, err = FindStepStatusByServiceRequestIDAndStatus(stepsStatusReq.ServiceRequestID, models.StatusStarted)
@@ -282,10 +304,11 @@ func TestFindStepStatusByServiceRequestIdAndStatusOrderByCreatedAtDesc(t *testin
 
 func TestFindStepStatusByServiceRequestIdAndStepIdAndStatus(t *testing.T) {
 	stepsStatusReq := prepareStepsStatus()
-	findStepStatusByServiceRequestIDAndStatusMock = func(serviceRequestId uuid.UUID, status models.Status) (statuses []models.StepsStatus, err error) {
+	findStepStatusByServiceRequestIDAndStatusMock = func(serviceRequestId uuid.UUID, status models.Status) (statuses []*models.StepsStatus, err error) {
 		step1Time := time.Date(2020, time.April, 07, 16, 32, 00, 00, time.UTC)
 
-		statuses = make([]models.StepsStatus, 1)
+		statuses = make([]*models.StepsStatus, 1)
+		statuses[0] = &models.StepsStatus{}
 		statuses[0].WorkflowName = "testWF"
 		statuses[0].ID = "1"
 		statuses[0].Status = models.StatusStarted
@@ -307,7 +330,7 @@ func TestFindStepStatusByServiceRequestIdAndStepIdAndStatus(t *testing.T) {
 	assert.Equal(t, "step1", stepsStatus.StepName)
 	assert.Equal(t, stepsStatusReq.TotalTimeInMs, stepsStatus.TotalTimeInMs)
 
-	findStepStatusByServiceRequestIDAndStatusMock = func(serviceRequestId uuid.UUID, status models.Status) (statuses []models.StepsStatus, err error) {
+	findStepStatusByServiceRequestIDAndStatusMock = func(serviceRequestId uuid.UUID, status models.Status) (statuses []*models.StepsStatus, err error) {
 		return statuses, errors.New("select query failed")
 	}
 	_, err = FindStepStatusByServiceRequestIDAndStatus(stepsStatusReq.ServiceRequestID, models.StatusStarted)
@@ -315,16 +338,19 @@ func TestFindStepStatusByServiceRequestIdAndStepIdAndStatus(t *testing.T) {
 }
 
 func TestShouldReturnStatusCompletedIfOneStepSkipped(t *testing.T) {
-	findStepStatusByServiceRequestIDMock = func(serviceRequestId uuid.UUID) (statuses []models.StepsStatus, err error) {
+	findStepStatusByServiceRequestIDMock = func(serviceRequestId uuid.UUID) (statuses []*models.StepsStatus, err error) {
 		step1Time := time.Date(2020, time.April, 07, 16, 32, 00, 00, time.UTC)
 
-		statuses = make([]models.StepsStatus, 4)
+		statuses = make([]*models.StepsStatus, 4)
+		statuses[0] = &models.StepsStatus{}
 		statuses[0].WorkflowName = "testWF"
 		statuses[0].ID = "1"
 		statuses[0].Status = models.StatusStarted
 		statuses[0].StepName = "step1"
 		statuses[0].TotalTimeInMs = 10
 		statuses[0].CreatedAt = step1Time
+
+		statuses[1] = &models.StepsStatus{}
 		statuses[1].WorkflowName = "testWF"
 		statuses[1].ID = "2"
 		statuses[1].Status = models.StatusSkipped
@@ -332,18 +358,22 @@ func TestShouldReturnStatusCompletedIfOneStepSkipped(t *testing.T) {
 		statuses[1].TotalTimeInMs = 20
 		statuses[1].CreatedAt = step1Time.Add(time.Second * 10)
 
+		statuses[2] = &models.StepsStatus{}
 		statuses[2].WorkflowName = "testWF"
 		statuses[2].ID = "3"
 		statuses[2].Status = models.StatusStarted
 		statuses[2].StepName = "step2"
 		statuses[2].TotalTimeInMs = 10
 		statuses[2].CreatedAt = step1Time.Add(time.Second * 20)
+
+		statuses[3] = &models.StepsStatus{}
 		statuses[3].WorkflowName = "testWF"
 		statuses[3].ID = "4"
 		statuses[3].Status = models.StatusCompleted
 		statuses[3].StepName = "step2"
 		statuses[3].TotalTimeInMs = 20
 		statuses[3].CreatedAt = step1Time.Add(time.Second * 30)
+
 		return statuses, err
 	}
 	serviceReqID := uuid.New()
@@ -356,7 +386,7 @@ func TestShouldReturnStatusCompletedIfOneStepSkipped(t *testing.T) {
 		UpdatedAt:   time.Time{},
 		Steps:       make([]models.Step, 2),
 	}
-	resp := PrepareStepStatusResponse(serviceReqID, workflow, stepsStatus)
+	resp := PrepareStepStatusResponse(serviceReqID, &workflow, stepsStatus)
 	assert.Nil(t, err)
 	assert.Equal(t, models.StatusCompleted, resp.Status)
 }

--- a/services/workflow_service.go
+++ b/services/workflow_service.go
@@ -7,7 +7,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func SaveWorkflow(workflowReq models.Workflow) (models.Workflow, error) {
+func SaveWorkflow(workflowReq *models.Workflow) (*models.Workflow, error) {
 	log.Debugf("Saving worflow %v", workflowReq)
 	workflow, err := repository.GetDB().SaveWorkflow(workflowReq)
 	if err != nil {
@@ -18,7 +18,7 @@ func SaveWorkflow(workflowReq models.Workflow) (models.Workflow, error) {
 	return workflow, err
 }
 
-func FindWorkflowByName(workflowName string) (models.Workflow, error) {
+func FindWorkflowByName(workflowName string) (*models.Workflow, error) {
 	log.Debugf("Finding workflow by name : %s", workflowName)
 	workflow, err := repository.GetDB().FindWorkflowByName(workflowName)
 	if err != nil {
@@ -41,7 +41,7 @@ func DeleteWorkflowByName(workflowName string) error {
 // GetWorkflows is used to fetch all the workflows for the GET call API
 // Implements a pagination approach
 // Also supports filters
-func GetWorkflows(pageNumber int, pageSize int, sortBy models.SortByFields) ([]models.Workflow, int, error) {
+func GetWorkflows(pageNumber int, pageSize int, sortBy models.SortByFields) ([]*models.Workflow, int, error) {
 	log.Debugf("Getting workflows for pageNumber: %d, pageSize: %d", pageNumber, pageSize)
 	workflows, totalWorkflowsCount, err := repository.GetDB().GetWorkflows(pageNumber, pageSize, sortBy)
 	if err != nil {

--- a/services/workflow_service_test.go
+++ b/services/workflow_service_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func prepareWorkflow() models.Workflow {
+func prepareWorkflow() *models.Workflow {
 	steps := []models.Step{{}}
 
 	steps[0] = models.Step{
@@ -24,12 +24,12 @@ func prepareWorkflow() models.Workflow {
 		Enabled:     false,
 		Steps:       steps,
 	}
-	return workflow
+	return &workflow
 }
 func TestSaveWorkflow(t *testing.T) {
 
 	workflow := prepareWorkflow()
-	SaveWorkflowMock = func(workflow models.Workflow) (models.Workflow, error) {
+	SaveWorkflowMock = func(workflow *models.Workflow) (*models.Workflow, error) {
 		return workflow, nil
 	}
 	response, err := SaveWorkflow(workflow)
@@ -40,7 +40,7 @@ func TestSaveWorkflow(t *testing.T) {
 	assert.Equal(t, workflow.Name, response.Name, fmt.Sprintf("Expected worflow name to be %s but was %s", workflow.Name, response.Name))
 	assert.Equal(t, workflow.Steps[0].Name, response.Steps[0].Name, fmt.Sprintf("Expected worflow first step name to be %s but was %s", workflow.Steps[0].Name, response.Steps[0].Name))
 
-	SaveWorkflowMock = func(workflow models.Workflow) (models.Workflow, error) {
+	SaveWorkflowMock = func(workflow *models.Workflow) (*models.Workflow, error) {
 		return workflow, errors.New("insertion failed")
 	}
 	response, err = SaveWorkflow(workflow)
@@ -50,14 +50,14 @@ func TestSaveWorkflow(t *testing.T) {
 func TestFindWorkflowByWorkflowName(t *testing.T) {
 	workflow := prepareWorkflow()
 
-	findWorkflowByNameMock = func(workflowName string) (models.Workflow, error) {
+	findWorkflowByNameMock = func(workflowName string) (*models.Workflow, error) {
 		return workflow, nil
 	}
 	resp, err := FindWorkflowByName(workflow.Name)
 	assert.Nil(t, err)
 	assert.Equal(t, workflow.Name, resp.Name)
 	assert.NotNil(t, resp.Steps)
-	findWorkflowByNameMock = func(workflowName string) (models.Workflow, error) {
+	findWorkflowByNameMock = func(workflowName string) (*models.Workflow, error) {
 		return workflow, errors.New("select query failed")
 	}
 	_, err = FindWorkflowByName(workflow.Name)
@@ -70,11 +70,11 @@ func TestGetWorkflowsWithoutSortByArgs(t *testing.T) {
 	var receivedSortByArgs models.SortByFields
 	var pgNumberReceived int
 	var pgSizeReceived int
-	getWorkflowsMock = func(pageNumber int, pageSize int, sortBy models.SortByFields) ([]models.Workflow, int, error) {
+	getWorkflowsMock = func(pageNumber int, pageSize int, sortBy models.SortByFields) ([]*models.Workflow, int, error) {
 		receivedSortByArgs = sortBy
 		pgNumberReceived = pageNumber
 		pgSizeReceived = pageSize
-		return []models.Workflow{workflow}, 1, nil
+		return []*models.Workflow{workflow}, 1, nil
 
 	}
 	pageSize := 1
@@ -95,11 +95,11 @@ func TestGetWorkflowsWithSortByArgs(t *testing.T) {
 	var receivedSortByArgs models.SortByFields
 	var pgNumberReceived int
 	var pgSizeReceived int
-	getWorkflowsMock = func(pageNumber int, pageSize int, sortBy models.SortByFields) ([]models.Workflow, int, error) {
+	getWorkflowsMock = func(pageNumber int, pageSize int, sortBy models.SortByFields) ([]*models.Workflow, int, error) {
 		receivedSortByArgs = sortBy
 		pgNumberReceived = pageNumber
 		pgSizeReceived = pageSize
-		return []models.Workflow{workflow}, 1, nil
+		return []*models.Workflow{workflow}, 1, nil
 
 	}
 	pageSize := 1

--- a/transform/xml_transform.go
+++ b/transform/xml_transform.go
@@ -5,6 +5,6 @@ type XMLTransform struct {
 	Keys map[string]interface{} `json:"keys"`
 }
 
-func (t XMLTransform) DoTransform(requestBody map[string]interface{}, prefix string) (map[string]interface{}, error) {
+func (t *XMLTransform) DoTransform(requestBody map[string]interface{}, prefix string) (map[string]interface{}, error) {
 	return requestBody, nil
 }


### PR DESCRIPTION
The following changeset replaces all most of the uses of struct by-value usage with by-ref usage. 

Struct by-value usage incurs the cost of copying/cloning the struct data which should be avoided where it is not required.

The function `CreateWorkflow` is broken. It was supposed to assign an increasing id to the primary and on-failure steps. But the existing implementation didn't work as expected. So, now I added a test case to verify the expected behaviour and also fixed the `CreateWorkflow` function.