### PR TITLE
Changes for handling error from function calls

### DIFF
--- a/executors/kafka_executor.go
+++ b/executors/kafka_executor.go
@@ -2,6 +2,7 @@ package executors
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/Shopify/sarama"
 	log "github.com/sirupsen/logrus"
@@ -25,7 +26,11 @@ func (val *KafkaVal) DoExecute(requestBody interface{}, prefix string) (interfac
 		return nil, err
 	}
 
-	requestJSONBytes, _ := json.Marshal(requestBody)
+	requestJSONBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("error while marshaling kafka executor request: %w", err)
+	}
+
 	msg := &sarama.ProducerMessage{
 		Topic: val.TopicName,
 		Value: sarama.StringEncoder(requestJSONBytes),

--- a/handlers/service_request_handler.go
+++ b/handlers/service_request_handler.go
@@ -105,8 +105,16 @@ func prepareServiceRequestResponse(serviceReq *models.ServiceRequest) models.Ser
 func readRequestPayload(c *gin.Context) map[string]interface{} {
 	var payload map[string]interface{}
 	if c.Request.Body != nil {
-		data, _ := ioutil.ReadAll(c.Request.Body)
-		_ = json.Unmarshal(data, &payload)
+		data, err := ioutil.ReadAll(c.Request.Body)
+		if err != nil {
+			log.Errorf("error while reading readRequestPayload request bod: %s", err)
+		}
+
+		err = json.Unmarshal(data, &payload)
+		if err != nil {
+			log.Errorf("error while unmarshaling readRequestPayload: %s", err)
+		}
+
 		log.Debug("Request Body", payload)
 	}
 	return payload

--- a/hooks/transform_hooks.go
+++ b/hooks/transform_hooks.go
@@ -55,7 +55,11 @@ func prepareSpecStringAsPerKazaamContract(transformedStructure map[string]interf
 		"spec":      transformedStructure,
 	}
 	spec[0] = specInterface
-	specString, _ := json.Marshal(spec)
+	specString, err := json.Marshal(spec)
+	if err != nil {
+		log.Errorf("error while marshaling spec: %s", err)
+	}
+
 	return specString
 }
 

--- a/listeners/kafka_consumer_listener.go
+++ b/listeners/kafka_consumer_listener.go
@@ -78,7 +78,11 @@ func consume(topic string, master sarama.Consumer) (chan *sarama.ConsumerMessage
 	consumers := make(chan *sarama.ConsumerMessage)
 	errors := make(chan *sarama.ConsumerError)
 
-	partitions, _ := master.Partitions(topic)
+	partitions, err := master.Partitions(topic)
+	if err != nil {
+		log.Errorf("error while retrieving partitions: %s", err)
+	}
+
 	for _, partition := range partitions {
 		consumer, err := master.ConsumePartition(topic, partition, sarama.OffsetNewest)
 		if err != nil {


### PR DESCRIPTION
Function call errors were not handled in the implementation in multiple places. The changeset handles the error by propagating to the caller function or logging the error in error level.

The tests are run to make sure there is no functionality broken by the changes.

Addresses #98 